### PR TITLE
ABI refactor

### DIFF
--- a/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
@@ -247,7 +247,7 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
         case TYPE_CODE_TUPLE:
             Object[] arr = (Object[]) value;
             encodeArrayLen(arr.length, dest);
-            TupleType.encodeObjects(this, arr, dest, (i) -> elementType);
+            TupleType.encodeObjects(dynamic, arr, dest, (i) -> elementType);
             return;
         default: throw new Error();
         }

--- a/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
@@ -236,73 +236,52 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
 
     @Override
     void encodeTail(Object value, ByteBuffer dest) {
-        encodeArrayTail(value, dest);
-    }
-
-    private void insert(int len, ByteBuffer dest, Runnable insert) {
-        if(length == DYNAMIC_LENGTH) {
-            Encoding.insertInt(len, dest);
-        }
-        insert.run();
-    }
-
-    private void encodeArrayTail(Object v, ByteBuffer dest) {
         switch (elementType.typeCode()) {
-        case TYPE_CODE_BOOLEAN: encodeBooleans((boolean[]) v, dest); return;
-        case TYPE_CODE_BYTE: encodeBytes(decodeIfString(v), dest); return;
-        case TYPE_CODE_INT: encodeInts((int[]) v, dest); return;
-        case TYPE_CODE_LONG: encodeLongs((long[]) v, dest); return;
+        case TYPE_CODE_BOOLEAN: encodeBooleans((boolean[]) value, dest); return;
+        case TYPE_CODE_BYTE: encodeBytes(decodeIfString(value), dest); return;
+        case TYPE_CODE_INT: encodeInts((int[]) value, dest); return;
+        case TYPE_CODE_LONG: encodeLongs((long[]) value, dest); return;
         case TYPE_CODE_BIG_INTEGER:
         case TYPE_CODE_BIG_DECIMAL:
         case TYPE_CODE_ARRAY:
-        case TYPE_CODE_TUPLE: encodeObjects((Object[]) v, dest); return;
+        case TYPE_CODE_TUPLE:
+            Object[] arr = (Object[]) value;
+            encodeArrayLen(arr.length, dest);
+            TupleType.encodeObjects(this, arr, dest, (i) -> elementType);
+            return;
         default: throw new Error();
         }
     }
 
+    private void encodeArrayLen(int len, ByteBuffer dest) {
+        if(length == DYNAMIC_LENGTH) {
+            Encoding.insertInt(len, dest);
+        }
+    }
+
     private void encodeBooleans(boolean[] arr, ByteBuffer dest) {
-        insert(arr.length, dest, () -> {
-            for (boolean e : arr) {
-                BooleanType.encodeBoolean(e, dest);
-            }
-        });
+        encodeArrayLen(arr.length, dest);
+        for (boolean e : arr) {
+            BooleanType.encodeBoolean(e, dest);
+        }
     }
 
     private void encodeBytes(byte[] arr, ByteBuffer dest) {
-        insert(arr.length, dest, () -> Encoding.insertBytesPadded(arr, dest));
+        encodeArrayLen(arr.length, dest);
+        Encoding.insertBytesPadded(arr, dest);
     }
 
     private void encodeInts(int[] arr, ByteBuffer dest) {
-        insert(arr.length, dest, () -> {
-            for (int e : arr) {
-                Encoding.insertInt(e, dest);
-            }
-        });
+        encodeArrayLen(arr.length, dest);
+        for (int e : arr) {
+            Encoding.insertInt(e, dest);
+        }
     }
 
     private void encodeLongs(long[] arr, ByteBuffer dest) {
-        insert(arr.length, dest, () -> {
-            for (long e : arr) {
-                Encoding.insertInt(e, dest);
-            }
-        });
-    }
-
-    private void encodeObjects(Object[] arr, ByteBuffer dest) {
-        if(dynamic) {
-            insert(arr.length, dest, () -> insertOffsets(arr, dest));
-        }
-        for (Object object : arr) {
-            elementType.encodeTail(object, dest);
-        }
-    }
-
-    private void insertOffsets(Object[] objects, ByteBuffer dest) {
-        if (elementType.dynamic) {
-            int nextOffset = objects.length * OFFSET_LENGTH_BYTES;
-            for (Object object : objects) {
-                nextOffset = Encoding.insertOffset(nextOffset, dest, elementType.byteLength(object));
-            }
+        encodeArrayLen(arr.length, dest);
+        for (long e : arr) {
+            Encoding.insertInt(e, dest);
         }
     }
 
@@ -377,7 +356,7 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
 
     private Object decodeObjects(int len, ByteBuffer bb, byte[] unitBuffer) {
         Object[] elements = (Object[]) Array.newInstance(elementType.clazz, len); // reflection ftw
-        decodeObjects(len, bb, unitBuffer, elements, (i) -> elementType);
+        TupleType.decodeObjects(len, bb, unitBuffer, elements, (i) -> elementType);
         return elements;
     }
 

--- a/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
@@ -126,11 +126,11 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
 
     @Override
     void encodeTail(Object value, ByteBuffer dest) {
-        encodeObjects(this, ((Tuple) value).elements, dest, (i) -> elementTypes[i]);
+        encodeObjects(dynamic, ((Tuple) value).elements, dest, (i) -> elementTypes[i]);
     }
 
-    static void encodeObjects(ABIType<?> _this, Object[] values, ByteBuffer dest, IntFunction<ABIType<?>> getType) {
-        int nextOffset = !_this.dynamic ? -1 : headLengthSum(values, getType);
+    static void encodeObjects(boolean dynamic, Object[] values, ByteBuffer dest, IntFunction<ABIType<?>> getType) {
+        int nextOffset = !dynamic ? -1 : headLengthSum(values, getType);
         for (int i = 0; i < values.length; i++) {
             nextOffset = getType.apply(i).encodeHead(values[i], dest, nextOffset);
         }

--- a/src/main/java/com/esaulpaugh/headlong/abi/UnitType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/UnitType.java
@@ -71,14 +71,8 @@ public abstract class UnitType<J> extends ABIType<J> { // J generally extends Nu
     }
 
     @Override
-    int encodeHead(Object value, ByteBuffer dest, int nextOffset) {
-        Encoding.insertInt(((Number) value).longValue(), dest);
-        return nextOffset;
-    }
-
-    @Override
     void encodeTail(Object value, ByteBuffer dest) {
-        encodeHead(value, dest, 0);
+        Encoding.insertInt(((Number) value).longValue(), dest);
     }
 
     final void validatePrimitive(long longVal) {

--- a/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
@@ -30,6 +30,7 @@ import static com.esaulpaugh.headlong.abi.ABIType.TYPE_CODE_ARRAY;
 import static com.esaulpaugh.headlong.abi.ABIType.TYPE_CODE_TUPLE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -279,33 +280,36 @@ public class ABIJSONTest {
     }
 
     @Test
-    public void testParseFunction() {
+    public void testParseFunctionA() {
+        final Function f = Function.fromJson(FUNCTION_A_JSON);
+        final TupleType in = f.getParamTypes();
+        final TupleType out = f.getOutputTypes();
+        final ABIType<?> out0 = out.get(0);
 
-        Function f;
+        System.out.println(f.getName() + " : " + f.getCanonicalSignature() + " : " + out0);
+        assertEquals(1, in.elementTypes.length);
+        assertEquals(1, out.elementTypes.length);
 
-        f = Function.fromJson(FUNCTION_A_JSON);
-        System.out.println(f.getName() + " : " + f.getCanonicalSignature() + " : " + f.getOutputTypes().get(0));
-        assertEquals(1, f.getParamTypes().elementTypes.length);
         assertEquals("foo((decimal,decimal)[][])", f.getCanonicalSignature());
-        assertEquals(1, f.getOutputTypes().elementTypes.length);
-        assertEquals("uint64", f.getOutputTypes().get(0).canonicalType);
+        assertEquals("uint64", out0.getCanonicalType());
+
+        assertFalse(out0.isDynamic());
         assertNull(f.getStateMutability());
         f.encodeCallWithArgs((Object) new Tuple[][] { new Tuple[] { new Tuple(new BigDecimal(BigInteger.ONE, 10), new BigDecimal(BigInteger.TEN, 10)) } });
 
-        printTupleType(f.getParamTypes());
+        printTupleType(in);
+        printTupleType(out);
+    }
 
-        printTupleType(f.getOutputTypes());
-
-        f = Function.fromJson(FUNCTION_B_JSON, Function.newDefaultDigest());
+    @Test
+    public void testParseFunctionB() {
+        final Function f = Function.fromJson(FUNCTION_B_JSON, Function.newDefaultDigest());
         System.out.println(f.getName() + " : " + f.getCanonicalSignature());
         assertEquals(TupleType.EMPTY, f.getOutputTypes());
         assertEquals("func((decimal,fixed128x18),fixed128x18[],(uint256,int256[],(int8,uint40)[]))", f.getCanonicalSignature());
         assertEquals("view", f.getStateMutability());
 
         printTupleType(f.getParamTypes());
-
-        Function f2 = Function.fromJson("{\"name\": \"foo\", \"type\": \"function\", \"inputs\": [ {\"name\": \"complex_nums\", \"type\": \"tuple[]\", \"components\": [ {\"name\": \"real\", \"type\": \"decimal\"}, {\"name\": \"imaginary\", \"type\": \"decimal\"} ]} ]}");
-        System.out.println(f2.toJson(false));
     }
 
     @Test


### PR DESCRIPTION
combine array encoding code with tuple encoding code;
move TupleType/ArrayType-specific methods out of ABIType;
no longer have UnitType override encodeHead (BigIntegerType and BigDecimalType still do);
refactor some method signatures in PackedDecoder;