### PR TITLE
Add `decodeArgs()` method for `Event`

### DIFF
--- a/src/main/java/com/esaulpaugh/headlong/abi/Event.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Event.java
@@ -186,7 +186,7 @@ public final class Event implements ABIObject {
         if (!Arrays.equals(decodedSignatureHash, signatureHash)) {
             String message = String.format("Decoded Event signature hash %s does not match the one from ABI %s",
                     FastHex.encodeToString(decodedSignatureHash), FastHex.encodeToString(signatureHash));
-            throw new RuntimeException(message);
+            throw new IllegalArgumentException(message);
         }
     }
 }

--- a/src/main/java/com/esaulpaugh/headlong/abi/Event.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Event.java
@@ -16,7 +16,10 @@
 package com.esaulpaugh.headlong.abi;
 
 import com.esaulpaugh.headlong.abi.util.JsonUtils;
+import com.esaulpaugh.headlong.util.FastHex;
+import com.esaulpaugh.headlong.util.Strings;
 import com.google.gson.JsonObject;
+import com.joemelsha.crypto.hash.Keccak;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -29,7 +32,10 @@ public final class Event implements ABIObject {
     private final String name;
     private final boolean anonymous;
     private final TupleType inputs;
+    private final TupleType indexedParams;
+    private final TupleType nonIndexedParams;
     private final boolean[] indexManifest;
+    private final byte[] signatureHash;
 
 
     public static Event create(String name, TupleType inputs, boolean... indexed) {
@@ -47,7 +53,10 @@ public final class Event implements ABIObject {
             throw new IllegalArgumentException("indexed.length doesn't match number of inputs");
         }
         this.indexManifest = Arrays.copyOf(indexed, indexed.length);
+        this.indexedParams = inputs.select(indexManifest);
+        this.nonIndexedParams = inputs.exclude(indexManifest);
         this.anonymous = anonymous;
+        this.signatureHash = new Keccak(256).digest(Strings.decode(getCanonicalSignature(), Strings.ASCII));
     }
 
     @Override
@@ -79,11 +88,11 @@ public final class Event implements ABIObject {
     }
 
     public TupleType getIndexedParams() {
-        return inputs.select(indexManifest);
+        return indexedParams;
     }
 
     public TupleType getNonIndexedParams() {
-        return inputs.exclude(indexManifest);
+        return nonIndexedParams;
     }
 
     @Override

--- a/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
@@ -468,4 +468,63 @@ public class DecodeTest {
         boolean b = bar.decodeSingletonReturn(Strings.decode("0000000000000000000000000000000000000000000000000000000000000001"));
         assertTrue(b);
     }
+
+    @Test
+    public void testDecodeEvent() {
+        Event event = Event.fromJson("{\n" +
+                "    \"anonymous\": false,\n" +
+                "    \"inputs\": [\n" +
+                "      {\n" +
+                "        \"indexed\": false,\n" +
+                "        \"name\": \"buyHash\",\n" +
+                "        \"type\": \"bytes32\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"indexed\": false,\n" +
+                "        \"name\": \"sellHash\",\n" +
+                "        \"type\": \"bytes32\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"indexed\": true,\n" +
+                "        \"name\": \"maker\",\n" +
+                "        \"type\": \"address\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"indexed\": true,\n" +
+                "        \"name\": \"taker\",\n" +
+                "        \"type\": \"address\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"indexed\": false,\n" +
+                "        \"name\": \"price\",\n" +
+                "        \"type\": \"uint256\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"indexed\": true,\n" +
+                "        \"name\": \"metadata\",\n" +
+                "        \"type\": \"bytes32\"\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"name\": \"OrdersMatched\",\n" +
+                "    \"type\": \"event\"\n" +
+                "  }");
+        byte[][] topics = {
+                FastHex.decode("c4109843e0b7d514e4c093114b863f8e7d8d9a458c372cd51bfe526b588006c9"),
+                FastHex.decode("000000000000000000000000bbb677a94eda9660832e9944353dd6e814a45705"),
+                FastHex.decode("000000000000000000000000bcead8896acb7a045c38287e433d896eefb40f6c"),
+                FastHex.decode("0000000000000000000000000000000000000000000000000000000000000000")
+        };
+        byte[] data = FastHex.decode("00000000000000000000000000000000000000000000000000000000000000009b5de4f892fe73b139777ff15eb165f359a0ea9ea1c687f8e8dc5748249ca5f200000000000000000000000000000000000000000000000002386f26fc100000");
+        Tuple result = event.decodeArgs(topics, data);
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000000",
+                Strings.encode((byte[]) result.get(0)));
+        assertEquals("9b5de4f892fe73b139777ff15eb165f359a0ea9ea1c687f8e8dc5748249ca5f2",
+                Strings.encode((byte[]) result.get(1)));
+        assertEquals("0xbbb677a94eda9660832e9944353dd6e814a45705", result.get(2).toString().toLowerCase());
+        assertEquals("0xbcead8896acb7a045c38287e433d896eefb40f6c", result.get(3).toString().toLowerCase());
+        assertEquals(new BigInteger("160000000000000000"), result.get(4));
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000000",
+                Strings.encode((byte[]) result.get(5)));
+
+    }
 }


### PR DESCRIPTION
Hey @esaulpaugh,

Here's my implementation of the decode function for Events.
I still need to add a few more tests for edge cases, but I wanted your opinion before doing so.
In a few words:
* Indexed parameters are passed as a `topics` array, that we can easily decode using the usual decoding functions. However, dynamic types are not decodable as only a special hash of their encoding is stored, so we decode that instead.
* Non-indexed parameters are all bundled in a `data` byte array, which we decode in one go. I'm not a fan of the `data` naming, but that's the terminology used in the [Solidity docs](https://docs.soliditylang.org/en/v0.8.11/abi-spec.html#events), so I figured it's better to stay consistent.
* We reconstruct and return a Tuple that contains all those parameters in the right order

This split between `topics` and `data` as input parameters is similar to what is done in [`ethereumj`](https://github.com/ethereum/ethereumj/blob/develop/ethereumj-core/src/main/java/org/ethereum/solidity/Abi.java#L287) or to how things are presented in tools like [etherscan](https://ropsten.etherscan.io/tx/0x030a0cf66141dd45312bc0f7b2954784767d3b079b8b154a52af0422a0a94a23#eventlog).

Would that implementation work for you? 
Feel free to also let me know about any code style changes you would like me to make, in order to match the project's choices in that regard.