### PR TITLE
include internal type from json

### DIFF
--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -297,6 +297,12 @@ public final class ABIJSON {
         }
     }
 
+    private static void internalType(JsonWriter out, String internalType) throws IOException {
+        if(internalType != null) {
+            out.name(INTERNAL_TYPE).value(internalType);
+        }
+    }
+
     private static void stateMutability(JsonWriter out, String stateMutability) throws IOException {
         if(stateMutability != null) {
             out.name(STATE_MUTABILITY).value(stateMutability);
@@ -308,6 +314,9 @@ public final class ABIJSON {
         int i = 0;
         for (final ABIType<?> e : tupleType) {
             out.beginObject();
+            if(tupleType.elementInternalTypes != null) {
+                internalType(out, tupleType.elementInternalTypes[i]);
+            }
             if(tupleType.elementNames != null) {
                 name(out, tupleType.elementNames[i]);
             }

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -229,7 +229,7 @@ public final class ABIJSON {
                 return parseTupleType(object, COMPONENTS);
             }
             TupleType baseType = parseTupleType(object, COMPONENTS);
-            return TypeFactory.build(baseType.canonicalType + type.substring(TUPLE.length()), null, null, baseType); // return ArrayType
+            return TypeFactory.build(baseType.canonicalType + type.substring(TUPLE.length()), null, baseType); // return ArrayType
         }
         return TypeFactory.create(type);
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import static com.esaulpaugh.headlong.abi.util.JsonUtils.getArray;
 import static com.esaulpaugh.headlong.abi.util.JsonUtils.getBoolean;
@@ -107,7 +106,7 @@ public final class ABIJSON {
                 final JsonObject object = e.getAsJsonObject();
                 final TypeEnum t = TypeEnum.parse(getType(object));
                 if(types.contains(t)) {
-                    selected.add(parseABIObject(t, object, () -> digest));
+                    selected.add(parseABIObject(t, object, digest));
                 }
             }
         }
@@ -116,16 +115,17 @@ public final class ABIJSON {
 
     /** @see ABIObject#fromJsonObject(JsonObject) */
     static <T extends ABIObject> T parseABIObject(JsonObject object) {
-        return parseABIObject(TypeEnum.parse(getType(object)), object, Function::newDefaultDigest);
+        final TypeEnum typeEnum = TypeEnum.parse(getType(object));
+        return parseABIObject(TypeEnum.parse(getType(object)), object, typeEnum.isFunction ? Function.newDefaultDigest() : null);
     }
 
     @SuppressWarnings("unchecked")
-    private static <T extends ABIObject> T parseABIObject(TypeEnum t, JsonObject object, Supplier<MessageDigest> digest) {
+    private static <T extends ABIObject> T parseABIObject(TypeEnum t, JsonObject object, MessageDigest digest) {
         switch (t.ordinal()) {
         case TypeEnum.ORDINAL_FUNCTION:
         case TypeEnum.ORDINAL_RECEIVE:
         case TypeEnum.ORDINAL_FALLBACK:
-        case TypeEnum.ORDINAL_CONSTRUCTOR: return (T) parseFunctionUnchecked(t, object, digest.get());
+        case TypeEnum.ORDINAL_CONSTRUCTOR: return (T) parseFunctionUnchecked(t, object, digest);
         case TypeEnum.ORDINAL_EVENT: return (T) parseEventUnchecked(object);
         case TypeEnum.ORDINAL_ERROR: return (T) parseErrorUnchecked(object);
         default: throw new AssertionError();

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
@@ -188,7 +188,7 @@ public abstract class ABIType<J> {
 
     public final J decodePacked(byte[] buffer) {
         return PackedDecoder.decode(
-                    new TupleType('(' + this.canonicalType + ')', dynamic, new ABIType[] { this }, null),
+                    new TupleType('(' + this.canonicalType + ')', dynamic, new ABIType[] { this }, null, null),
                     buffer
                 ).get(0);
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/Function.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Function.java
@@ -162,7 +162,7 @@ public final class Function implements ABIObject {
             return;
         case ORDINAL_EVENT:
         case ORDINAL_ERROR:
-        default: throw TypeEnum.unexpectedType(type.name);
+        default: throw TypeEnum.unexpectedType(type.toString());
         }
     }
 

--- a/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
@@ -32,18 +32,20 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
     static final String EMPTY_TUPLE_STRING = "()";
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
-    public static final TupleType EMPTY = new TupleType(EMPTY_TUPLE_STRING, false, EMPTY_ARRAY, null);
+    public static final TupleType EMPTY = new TupleType(EMPTY_TUPLE_STRING, false, EMPTY_ARRAY, null, null);
 
     final ABIType<?>[] elementTypes;
     final String[] elementNames;
+    final String[] elementInternalTypes;
     private final int[] elementHeadOffsets;
     private final int headLength;
     private final int firstOffset;
 
-    TupleType(String canonicalType, boolean dynamic, ABIType<?>[] elementTypes, String[] elementNames) {
+    TupleType(String canonicalType, boolean dynamic, ABIType<?>[] elementTypes, String[] elementNames, String[] elementInternalTypes) {
         super(canonicalType, Tuple.class, dynamic);
         this.elementTypes = elementTypes;
         this.elementNames = elementNames;
+        this.elementInternalTypes = elementInternalTypes;
         this.elementHeadOffsets = new int[elementTypes.length];
         if(dynamic) {
             this.headLength = OFFSET_LENGTH_BYTES;
@@ -72,6 +74,13 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
             throw new IllegalArgumentException("index out of bounds: " + index);
         }
         return elementNames == null ? null : elementNames[index];
+    }
+
+    public String getElementInternalType(int index) {
+        if(index < 0 || index >= size()) {
+            throw new IllegalArgumentException("index out of bounds: " + index);
+        }
+        return elementInternalTypes == null ? null : elementInternalTypes[index];
     }
 
     @SuppressWarnings("unchecked")
@@ -351,6 +360,7 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
             boolean dynamic = false;
             final List<ABIType<?>> selected = new ArrayList<>(size);
             final List<String> selectedNames = new ArrayList<>(size);
+            final List<String> selectedInternalTypes = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
                 if (negate ^ manifest[i]) {
                     ABIType<?> e = get(i);
@@ -358,9 +368,16 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
                     dynamic |= e.dynamic;
                     selected.add(e);
                     selectedNames.add(elementNames == null ? null : elementNames[i]);
+                    selectedInternalTypes.add(elementInternalTypes == null ? null : elementInternalTypes[i]);
                 }
             }
-            return new TupleType(completeTupleTypeString(canonicalBuilder), dynamic, selected.toArray(EMPTY_ARRAY), selectedNames.toArray(EMPTY_STRING_ARRAY));
+            return new TupleType(
+                    completeTupleTypeString(canonicalBuilder),
+                    dynamic,
+                    selected.toArray(EMPTY_ARRAY),
+                    selectedNames.toArray(EMPTY_STRING_ARRAY),
+                    selectedInternalTypes.toArray(EMPTY_STRING_ARRAY)
+            );
         }
         throw new IllegalArgumentException("manifest.length != size(): " + manifest.length + " != " + size);
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
@@ -359,24 +359,28 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
             final StringBuilder canonicalBuilder = new StringBuilder("(");
             boolean dynamic = false;
             final List<ABIType<?>> selected = new ArrayList<>(size);
-            final List<String> selectedNames = new ArrayList<>(size);
-            final List<String> selectedInternalTypes = new ArrayList<>(size);
+            final List<String> selectedNames = elementNames == null ? null : new ArrayList<>(size);
+            final List<String> selectedInternalTypes = elementInternalTypes == null ? null : new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
                 if (negate ^ manifest[i]) {
                     ABIType<?> e = get(i);
                     canonicalBuilder.append(e.canonicalType).append(',');
                     dynamic |= e.dynamic;
                     selected.add(e);
-                    selectedNames.add(elementNames == null ? null : elementNames[i]);
-                    selectedInternalTypes.add(elementInternalTypes == null ? null : elementInternalTypes[i]);
+                    if (selectedNames != null) {
+                        selectedNames.add(elementNames[i]);
+                    }
+                    if (selectedInternalTypes != null) {
+                        selectedInternalTypes.add(elementInternalTypes[i]);
+                    }
                 }
             }
             return new TupleType(
                     completeTupleTypeString(canonicalBuilder),
                     dynamic,
                     selected.toArray(EMPTY_ARRAY),
-                    selectedNames.toArray(EMPTY_STRING_ARRAY),
-                    selectedInternalTypes.toArray(EMPTY_STRING_ARRAY)
+                    selectedNames == null ? null : selectedNames.toArray(EMPTY_STRING_ARRAY),
+                    selectedInternalTypes == null ? null : selectedInternalTypes.toArray(EMPTY_STRING_ARRAY)
             );
         }
         throw new IllegalArgumentException("manifest.length != size(): " + manifest.length + " != " + size);

--- a/src/main/java/com/esaulpaugh/headlong/abi/TypeEnum.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TypeEnum.java
@@ -17,12 +17,12 @@ package com.esaulpaugh.headlong.abi;
 
 public enum TypeEnum {
 
-    FUNCTION(ABIJSON.FUNCTION),
-    RECEIVE(ABIJSON.RECEIVE),
-    FALLBACK(ABIJSON.FALLBACK),
-    CONSTRUCTOR(ABIJSON.CONSTRUCTOR),
-    EVENT(ABIJSON.EVENT),
-    ERROR(ABIJSON.ERROR);
+    FUNCTION(ABIJSON.FUNCTION, true),
+    RECEIVE(ABIJSON.RECEIVE, true),
+    FALLBACK(ABIJSON.FALLBACK, true),
+    CONSTRUCTOR(ABIJSON.CONSTRUCTOR, true),
+    EVENT(ABIJSON.EVENT, false),
+    ERROR(ABIJSON.ERROR, false);
 
     static final int ORDINAL_FUNCTION = 0;
     static final int ORDINAL_RECEIVE = 1;
@@ -31,10 +31,12 @@ public enum TypeEnum {
     static final int ORDINAL_EVENT = 4;
     static final int ORDINAL_ERROR = 5;
 
-    final String name;
+    private final String name;
+    public final boolean isFunction;
 
-    TypeEnum(String name) {
+    TypeEnum(String name, boolean isFunction) {
         this.name = name;
+        this.isFunction = isFunction;
     }
 
     @Override

--- a/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
@@ -104,27 +104,27 @@ public final class TypeFactory {
 
     @SuppressWarnings("unchecked")
     public static <T extends ABIType<?>> T create(String rawType) {
-        return (T) build(rawType, null, null, null);
+        return (T) build(rawType, null, null);
     }
 
     @SuppressWarnings("unchecked")
     public static ABIType<Object> createNonCapturing(String rawType) {
-        return (ABIType<Object>) build(rawType, null, null, null);
+        return (ABIType<Object>) build(rawType, null, null);
     }
 
     /** If you don't need any {@code elementNames}, use {@link TypeFactory#create(String)}. */
     public static TupleType createTupleTypeWithNames(String rawType, String... elementNames) {
-        return (TupleType) build(rawType, elementNames, null, null);
+        return (TupleType) build(rawType, elementNames, null);
     }
 
-    static ABIType<?> build(String rawType, String[] elementNames, String[] elementInternalTypes, ABIType<?> baseType) {
+    static ABIType<?> build(String rawType, String[] elementNames, ABIType<?> baseType) {
         if(rawType.length() > MAX_LENGTH_CHARS) {
             throw new IllegalArgumentException("type length exceeds maximum: " + rawType.length() + " > " + MAX_LENGTH_CHARS);
         }
-        return buildUnchecked(rawType, elementNames, elementInternalTypes, baseType);
+        return buildUnchecked(rawType, elementNames, baseType);
     }
 
-    private static ABIType<?> buildUnchecked(final String rawType, final String[] elementNames, final String[] elementInternalTypes, ABIType<?> baseType) {
+    private static ABIType<?> buildUnchecked(final String rawType, final String[] elementNames, ABIType<?> baseType) {
         try {
             final int lastCharIdx = rawType.length() - 1;
             if (rawType.charAt(lastCharIdx) == ']') { // array
@@ -132,12 +132,12 @@ public final class TypeFactory {
                 final int secondToLastCharIdx = lastCharIdx - 1;
                 final int arrayOpenIndex = rawType.lastIndexOf('[', secondToLastCharIdx);
 
-                final ABIType<?> elementType = buildUnchecked(rawType.substring(0, arrayOpenIndex), null, null, baseType);
+                final ABIType<?> elementType = buildUnchecked(rawType.substring(0, arrayOpenIndex), null, baseType);
                 final String type = elementType.canonicalType + rawType.substring(arrayOpenIndex);
                 final int length = arrayOpenIndex == secondToLastCharIdx ? DYNAMIC_LENGTH : parseLen(rawType.substring(arrayOpenIndex + 1, lastCharIdx));
                 return new ArrayType<>(type, elementType.arrayClass(), elementType, length, null);
             }
-            if(baseType != null || (baseType = resolveBaseType(rawType, elementNames, elementInternalTypes)) != null) {
+            if(baseType != null || (baseType = resolveBaseType(rawType, elementNames)) != null) {
                 return baseType;
             }
         } catch (StringIndexOutOfBoundsException ignored) { // e.g. type equals "" or "82]" or "[]" or "[1]"
@@ -161,9 +161,9 @@ public final class TypeFactory {
         throw new IllegalArgumentException("bad array length");
     }
 
-    private static ABIType<?> resolveBaseType(final String baseTypeStr, final String[] elementNames, final String[] elementInternalTypes) {
+    private static ABIType<?> resolveBaseType(final String baseTypeStr, final String[] elementNames) {
         if (baseTypeStr.charAt(0) == '(') {
-            return parseTupleType(baseTypeStr, elementNames, elementInternalTypes);
+            return parseTupleType(baseTypeStr, elementNames);
         }
         final ABIType<?> ret = BASE_TYPE_MAP.get(baseTypeStr);
         return ret != null ? ret : tryParseFixed(baseTypeStr);
@@ -195,7 +195,7 @@ public final class TypeFactory {
         return c > '0' && c <= '9';
     }
 
-    private static TupleType parseTupleType(final String rawTypeStr, final String[] elementNames, final String[] elementInternalTypes) { /* assumes that rawTypeStr.charAt(0) == '(' */
+    private static TupleType parseTupleType(final String rawTypeStr, final String[] elementNames) { /* assumes that rawTypeStr.charAt(0) == '(' */
         final int len = rawTypeStr.length();
         if (len == 2 && rawTypeStr.equals(EMPTY_TUPLE_STRING)) return TupleType.EMPTY;
         final List<ABIType<?>> elements = new ArrayList<>();
@@ -211,7 +211,7 @@ public final class TypeFactory {
                 case '(': argEnd = nextTerminator(rawTypeStr, findSubtupleEnd(rawTypeStr, argStart + 1)); break;
                 default: argEnd = nextTerminator(rawTypeStr, argStart);
                 }
-                final ABIType<?> e = buildUnchecked(rawTypeStr.substring(argStart, argEnd), null, null, null);
+                final ABIType<?> e = buildUnchecked(rawTypeStr.substring(argStart, argEnd), null, null);
                 canonicalBuilder.append(e.canonicalType).append(',');
                 dynamic |= e.dynamic;
                 elements.add(e);
@@ -222,16 +222,13 @@ public final class TypeFactory {
         if (elementNames != null && elementNames.length != elements.size()) {
             throw new IllegalArgumentException("expected " + elements.size() + " element names but found " + elementNames.length);
         }
-        if (elementInternalTypes != null && elementInternalTypes.length != elements.size()) {
-            throw new IllegalArgumentException("expected " + elements.size() + " element names but found " + elementInternalTypes.length);
-        }
         return argEnd == len
                 ? new TupleType(
                     canonicalBuilder.deleteCharAt(canonicalBuilder.length() - 1).append(')').toString(),
                     dynamic,
                     elements.toArray(EMPTY_ARRAY),
                     elementNames,
-                    elementInternalTypes
+                    null
                 )
                 : null;
     }

--- a/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
@@ -744,4 +744,44 @@ public class ABIJSONTest {
 
         assertEquals(eventStr, e.toString());
     }
+
+    @Test
+    public void testUserDefinedValueTypes() {
+        String json = "{\n" +
+                "  \"type\": \"constructor\",\n" +
+                "  \"inputs\": [\n" +
+                "    {\n" +
+                "      \"internalType\": \"MyNamespace.UIntMax\",\n" +
+                "      \"name\": \"unsigned256\",\n" +
+                "      \"type\": \"uint256\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"internalType\": \"CustomType\",\n" +
+                "      \"name\": \"signed24\",\n" +
+                "      \"type\": \"int24\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"internalType\": \"SomeOtherDudesNamespace.Bytes\",\n" +
+                "      \"name\": \"byteArr\",\n" +
+                "      \"type\": \"bytes\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"internalType\": \"contract AContract\",\n" +
+                "      \"name\": \"contractAddr\",\n" +
+                "      \"type\": \"address\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"stateMutability\": \"pure\"\n" +
+                "}";
+
+        Function f = Function.fromJson(json);
+
+        TupleType in = f.getInputs();
+        assertEquals("MyNamespace.UIntMax", in.getElementInternalType(0));
+        assertEquals("CustomType", in.getElementInternalType(1));
+        assertEquals("SomeOtherDudesNamespace.Bytes", in.getElementInternalType(2));
+        assertEquals("contract AContract", in.getElementInternalType(3));
+
+        assertEquals(json, f.toString());
+    }
 }

--- a/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
@@ -705,4 +705,43 @@ public class ABIJSONTest {
                     .flatMap(ABIJSONTest::flatten)
                 : Stream.of(type);
     }
+
+    @Test
+    public void testInternalType() {
+        String eventStr =
+                "{\n" +
+                "  \"type\": \"event\",\n" +
+                "  \"name\": \"ManyThings\",\n" +
+                "  \"inputs\": [\n" +
+                "    {\n" +
+                "      \"internalType\": \"struct Thing[]\",\n" +
+                "      \"name\": \"thing\",\n" +
+                "      \"type\": \"tuple[]\",\n" +
+                "      \"components\": [\n" +
+                "        {\n" +
+                "          \"name\": \"thing_string\",\n" +
+                "          \"type\": \"string\"\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"indexed\": false\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"anonymous\": false\n" +
+                "}";
+
+        Event e = Event.fromJson(eventStr);
+
+        TupleType in = e.getInputs();
+        assertEquals("struct Thing[]", in.getElementInternalType(0));
+
+        TupleType indexed = e.getIndexedParams();
+        assertEquals(0, indexed.size());
+
+        TupleType nonIndexed = e.getNonIndexedParams();
+        assertEquals("struct Thing[]", nonIndexed.getElementInternalType(0));
+
+        System.out.println(e);
+
+        assertEquals(eventStr, e.toString());
+    }
 }

--- a/src/test/java/com/esaulpaugh/headlong/abi/BasicABICasesTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/BasicABICasesTest.java
@@ -109,7 +109,7 @@ public class BasicABICasesTest {
             canonicalBuilder.append(e.canonicalType).append(',');
             dynamic |= e.dynamic;
         }
-        return new TupleType(completeTupleTypeString(canonicalBuilder), dynamic, elements, null);
+        return new TupleType(completeTupleTypeString(canonicalBuilder), dynamic, elements, null, null);
     }
 
     private static String completeTupleTypeString(StringBuilder sb) {

--- a/src/test/java/com/esaulpaugh/headlong/abi/TupleTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/TupleTest.java
@@ -331,7 +331,7 @@ public class TupleTest {
             canonicalBuilder.append(e.canonicalType).append(',');
             dynamic |= e.dynamic;
         }
-        return new TupleType(completeTupleTypeString(canonicalBuilder), dynamic, elements, elementNames);
+        return new TupleType(completeTupleTypeString(canonicalBuilder), dynamic, elements, elementNames, null);
     }
 
     private static String completeTupleTypeString(StringBuilder sb) {


### PR DESCRIPTION
Read and store the internalType information when using JSON to construct a TupleType.

Add internalType field to JSON output (if not null).