### PR TITLE
add flag for decoding byte arrays/strings assuming no trailing padding

### DIFF
--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -102,7 +102,7 @@ public final class ABIJSON {
         return parseElements(arrayJson, types, ABIType.FLAGS_NONE);
     }
 
-    private static <T extends ABIObject> List<T> parseElements(String arrayJson, Set<TypeEnum> types, int flags) {
+    public static <T extends ABIObject> List<T> parseElements(String arrayJson, Set<TypeEnum> types, int flags) {
         final List<T> selected = new ArrayList<>();
         final MessageDigest digest = Function.newDefaultDigest();
         for (final JsonElement e : parseArray(arrayJson)) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -218,7 +218,8 @@ public final class ABIJSON {
                 dynamic,
                 elements,
                 names,
-                internalTypes
+                internalTypes,
+                flags
         );
     }
 

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -99,10 +99,10 @@ public final class ABIJSON {
     }
 
     public static <T extends ABIObject> List<T> parseElements(String arrayJson, Set<TypeEnum> types) {
-        return parseElements(arrayJson, types, ABIType.FLAGS_NONE);
+        return parseElements(ABIType.FLAGS_NONE, arrayJson, types);
     }
 
-    public static <T extends ABIObject> List<T> parseElements(String arrayJson, Set<TypeEnum> types, int flags) {
+    public static <T extends ABIObject> List<T> parseElements(int flags, String arrayJson, Set<TypeEnum> types) {
         final List<T> selected = new ArrayList<>();
         final MessageDigest digest = Function.newDefaultDigest();
         for (final JsonElement e : parseArray(arrayJson)) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -117,7 +117,7 @@ public final class ABIJSON {
         return selected;
     }
 
-    /** @see ABIObject#fromJsonObject(JsonObject,int) */
+    /** @see ABIObject#fromJsonObject(int,JsonObject) */
     static <T extends ABIObject> T parseABIObject(JsonObject object, int flags) {
         final TypeEnum typeEnum = TypeEnum.parse(getType(object));
         return parseABIObject(TypeEnum.parse(getType(object)), object, typeEnum.isFunction ? Function.newDefaultDigest() : null, flags);
@@ -236,7 +236,7 @@ public final class ABIJSON {
             TupleType baseType = parseTupleType(object, COMPONENTS, flags);
             return TypeFactory.build(baseType.canonicalType + type.substring(TUPLE.length()), null, baseType, flags); // return ArrayType
         }
-        return TypeFactory.create(type, flags);
+        return TypeFactory.create(flags, type);
     }
 
     private static String getType(JsonObject obj) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -190,7 +190,7 @@ public final class ABIJSON {
     private static TupleType parseTupleType(final JsonArray array, final boolean[] indexed, final int flags) {
         int size;
         if (array == null || (size = array.size()) <= 0) { /* JsonArray.isEmpty requires gson v2.8.7 */
-            return TupleType.EMPTY;
+            return TupleType.empty(flags);
         }
         final ABIType<?>[] elements = new ABIType<?>[size];
         final String[] names = new String[size];

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -99,11 +99,7 @@ public final class ABIJSON {
     }
 
     public static <T extends ABIObject> List<T> parseElements(String arrayJson, Set<TypeEnum> types) {
-        return parseElements(arrayJson, types, ArrayType.NO_FLAGS);
-    }
-
-    public static <T extends ABIObject> List<T> parseElementsLegacy(String arrayJson, Set<TypeEnum> types) {
-        return parseElements(arrayJson, types, ArrayType.FLAG_LEGACY);
+        return parseElements(arrayJson, types, ABIType.FLAGS_NONE);
     }
 
     private static <T extends ABIObject> List<T> parseElements(String arrayJson, Set<TypeEnum> types, int flags) {
@@ -121,7 +117,7 @@ public final class ABIJSON {
         return selected;
     }
 
-    /** @see ABIObject#fromJsonObject(JsonObject) */
+    /** @see ABIObject#fromJsonObject(JsonObject,int) */
     static <T extends ABIObject> T parseABIObject(JsonObject object, int flags) {
         final TypeEnum typeEnum = TypeEnum.parse(getType(object));
         return parseABIObject(TypeEnum.parse(getType(object)), object, typeEnum.isFunction ? Function.newDefaultDigest() : null, flags);

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -99,6 +99,14 @@ public final class ABIJSON {
     }
 
     public static <T extends ABIObject> List<T> parseElements(String arrayJson, Set<TypeEnum> types) {
+        return parseElements(arrayJson, types, ArrayType.NO_FLAGS);
+    }
+
+    public static <T extends ABIObject> List<T> parseElementsLegacy(String arrayJson, Set<TypeEnum> types) {
+        return parseElements(arrayJson, types, ArrayType.FLAG_LEGACY);
+    }
+
+    private static <T extends ABIObject> List<T> parseElements(String arrayJson, Set<TypeEnum> types, int flags) {
         final List<T> selected = new ArrayList<>();
         final MessageDigest digest = Function.newDefaultDigest();
         for (final JsonElement e : parseArray(arrayJson)) {
@@ -106,7 +114,7 @@ public final class ABIJSON {
                 final JsonObject object = e.getAsJsonObject();
                 final TypeEnum t = TypeEnum.parse(getType(object));
                 if(types.contains(t)) {
-                    selected.add(parseABIObject(t, object, digest));
+                    selected.add(parseABIObject(t, object, digest, flags));
                 }
             }
         }
@@ -114,76 +122,76 @@ public final class ABIJSON {
     }
 
     /** @see ABIObject#fromJsonObject(JsonObject) */
-    static <T extends ABIObject> T parseABIObject(JsonObject object) {
+    static <T extends ABIObject> T parseABIObject(JsonObject object, int flags) {
         final TypeEnum typeEnum = TypeEnum.parse(getType(object));
-        return parseABIObject(TypeEnum.parse(getType(object)), object, typeEnum.isFunction ? Function.newDefaultDigest() : null);
+        return parseABIObject(TypeEnum.parse(getType(object)), object, typeEnum.isFunction ? Function.newDefaultDigest() : null, flags);
     }
 
     @SuppressWarnings("unchecked")
-    private static <T extends ABIObject> T parseABIObject(TypeEnum t, JsonObject object, MessageDigest digest) {
+    private static <T extends ABIObject> T parseABIObject(TypeEnum t, JsonObject object, MessageDigest digest, int flags) {
         switch (t.ordinal()) {
         case TypeEnum.ORDINAL_FUNCTION:
         case TypeEnum.ORDINAL_RECEIVE:
         case TypeEnum.ORDINAL_FALLBACK:
-        case TypeEnum.ORDINAL_CONSTRUCTOR: return (T) parseFunctionUnchecked(t, object, digest);
-        case TypeEnum.ORDINAL_EVENT: return (T) parseEventUnchecked(object);
-        case TypeEnum.ORDINAL_ERROR: return (T) parseErrorUnchecked(object);
+        case TypeEnum.ORDINAL_CONSTRUCTOR: return (T) parseFunctionUnchecked(t, object, digest, flags);
+        case TypeEnum.ORDINAL_EVENT: return (T) parseEventUnchecked(object, flags);
+        case TypeEnum.ORDINAL_ERROR: return (T) parseErrorUnchecked(object, flags);
         default: throw new AssertionError();
         }
     }
 // ---------------------------------------------------------------------------------------------------------------------
-    static Function parseFunction(JsonObject function, MessageDigest digest) {
+    static Function parseFunction(JsonObject function, MessageDigest digest, int flags) {
         final TypeEnum t = TypeEnum.parse(getType(function));
         if (FUNCTIONS.contains(t)) {
-            return parseFunctionUnchecked(t, function, digest);
+            return parseFunctionUnchecked(t, function, digest, flags);
         }
         throw TypeEnum.unexpectedType(getType(function));
     }
 
-    static Event parseEvent(JsonObject event) {
+    static Event parseEvent(JsonObject event, int flags) {
         if(!EVENT.equals(getType(event))) {
             throw TypeEnum.unexpectedType(getType(event));
         }
-        return parseEventUnchecked(event);
+        return parseEventUnchecked(event, flags);
     }
 
-    static ContractError parseError(JsonObject error) {
+    static ContractError parseError(JsonObject error, int flags) {
         if(!ERROR.equals(getType(error))) {
             throw TypeEnum.unexpectedType(getType(error));
         }
-        return parseErrorUnchecked(error);
+        return parseErrorUnchecked(error, flags);
     }
 
-    private static Function parseFunctionUnchecked(TypeEnum type, JsonObject function, MessageDigest digest) {
+    private static Function parseFunctionUnchecked(TypeEnum type, JsonObject function, MessageDigest digest, int flags) {
         return new Function(
                 type,
                 getName(function),
-                parseTupleType(function, INPUTS),
-                parseTupleType(function, OUTPUTS),
+                parseTupleType(function, INPUTS, flags),
+                parseTupleType(function, OUTPUTS, flags),
                 getString(function, STATE_MUTABILITY),
                 digest
         );
     }
 
-    private static Event parseEventUnchecked(JsonObject event) {
+    private static Event parseEventUnchecked(JsonObject event, int flags) {
         final JsonArray inputs = getArray(event, INPUTS);
         if (inputs != null) {
             final boolean[] indexed = new boolean[inputs.size()];
             return new Event(
                     getName(event),
                     getBoolean(event, ANONYMOUS, false),
-                    parseTupleType(inputs, indexed),
+                    parseTupleType(inputs, indexed, flags),
                     indexed
             );
         }
         throw new IllegalArgumentException("array \"" + INPUTS + "\" null or not found");
     }
 
-    private static ContractError parseErrorUnchecked(JsonObject error) {
-        return new ContractError(getName(error), parseTupleType(error, INPUTS));
+    private static ContractError parseErrorUnchecked(JsonObject error, int flags) {
+        return new ContractError(getName(error), parseTupleType(error, INPUTS, flags));
     }
 
-    private static TupleType parseTupleType(final JsonArray array, final boolean[] indexed) {
+    private static TupleType parseTupleType(final JsonArray array, final boolean[] indexed, final int flags) {
         int size;
         if (array == null || (size = array.size()) <= 0) { /* JsonArray.isEmpty requires gson v2.8.7 */
             return TupleType.EMPTY;
@@ -195,7 +203,7 @@ public final class ABIJSON {
         boolean dynamic = false;
         for (int i = 0; i < elements.length; i++) {
             final JsonObject inputObj = array.get(i).getAsJsonObject();
-            final ABIType<?> e = parseType(inputObj);
+            final ABIType<?> e = parseType(inputObj, flags);
             canonicalBuilder.append(e.canonicalType).append(',');
             dynamic |= e.dynamic;
             elements[i] = e;
@@ -218,20 +226,20 @@ public final class ABIJSON {
         );
     }
 
-    private static TupleType parseTupleType(JsonObject object, String arrayKey) {
-        return parseTupleType(getArray(object, arrayKey), null);
+    private static TupleType parseTupleType(JsonObject object, String arrayKey, int flags) {
+        return parseTupleType(getArray(object, arrayKey), null, flags);
     }
 
-    private static ABIType<?> parseType(JsonObject object) {
+    private static ABIType<?> parseType(JsonObject object, int flags) {
         final String type = getType(object);
         if(type.startsWith(TUPLE)) {
             if(type.length() == TUPLE.length()) {
-                return parseTupleType(object, COMPONENTS);
+                return parseTupleType(object, COMPONENTS, flags);
             }
-            TupleType baseType = parseTupleType(object, COMPONENTS);
-            return TypeFactory.build(baseType.canonicalType + type.substring(TUPLE.length()), null, baseType); // return ArrayType
+            TupleType baseType = parseTupleType(object, COMPONENTS, flags);
+            return TypeFactory.build(baseType.canonicalType + type.substring(TUPLE.length()), null, baseType, flags); // return ArrayType
         }
-        return TypeFactory.create(type);
+        return TypeFactory.create(type, flags);
     }
 
     private static String getType(JsonObject obj) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIObject.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIObject.java
@@ -57,11 +57,11 @@ public interface ABIObject {
         return (ContractError) this;
     }
 
-    static <T extends ABIObject> T fromJson(String json) {
-        return fromJsonObject(JsonUtils.parseObject(json));
+    static <T extends ABIObject> T fromJson(String json, int flags) {
+        return fromJsonObject(JsonUtils.parseObject(json), flags);
     }
 
-    static <T extends ABIObject> T fromJsonObject(JsonObject object) {
-        return ABIJSON.parseABIObject(object);
+    static <T extends ABIObject> T fromJsonObject(JsonObject object, int flags) {
+        return ABIJSON.parseABIObject(object, flags);
     }
 }

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIObject.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIObject.java
@@ -57,11 +57,19 @@ public interface ABIObject {
         return (ContractError) this;
     }
 
-    static <T extends ABIObject> T fromJson(String json, int flags) {
-        return fromJsonObject(JsonUtils.parseObject(json), flags);
+    static <T extends ABIObject> T fromJson(String json) {
+        return fromJsonObject(JsonUtils.parseObject(json));
     }
 
-    static <T extends ABIObject> T fromJsonObject(JsonObject object, int flags) {
+    static <T extends ABIObject> T fromJsonObject(JsonObject object) {
+        return ABIJSON.parseABIObject(object, ABIType.FLAGS_NONE);
+    }
+
+    static <T extends ABIObject> T fromJson(int flags, String json) {
+        return fromJsonObject(flags, JsonUtils.parseObject(json));
+    }
+
+    static <T extends ABIObject> T fromJsonObject(int flags, JsonObject object) {
         return ABIJSON.parseABIObject(object, flags);
     }
 }

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIObject.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIObject.java
@@ -61,10 +61,19 @@ public interface ABIObject {
         return fromJsonObject(ABIType.FLAGS_NONE, JsonUtils.parseObject(json));
     }
 
+    /** @see #fromJsonObject(int, JsonObject) */
     static <T extends ABIObject> T fromJson(int flags, String json) {
         return fromJsonObject(flags, JsonUtils.parseObject(json));
     }
 
+    /**
+     * Constructs an {@link ABIObject} from a {@link JsonObject}.
+     *
+     * @param flags     {@link ABIType#FLAGS_NONE} recommended. See also {@link ABIType#FLAG_LEGACY_DECODE}
+     * @param object    the JSON object to decode
+     * @return  the {@link ABIObject} represented by {@code object}
+     * @param <T>   {@link Function}, {@link Event}, {@link ContractError}, or supertype {@link ABIObject}
+     */
     static <T extends ABIObject> T fromJsonObject(int flags, JsonObject object) {
         return ABIJSON.parseABIObject(object, flags);
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIObject.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIObject.java
@@ -58,11 +58,7 @@ public interface ABIObject {
     }
 
     static <T extends ABIObject> T fromJson(String json) {
-        return fromJsonObject(JsonUtils.parseObject(json));
-    }
-
-    static <T extends ABIObject> T fromJsonObject(JsonObject object) {
-        return ABIJSON.parseABIObject(object, ABIType.FLAGS_NONE);
+        return fromJsonObject(ABIType.FLAGS_NONE, JsonUtils.parseObject(json));
     }
 
     static <T extends ABIObject> T fromJson(int flags, String json) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
@@ -31,7 +31,7 @@ import static com.esaulpaugh.headlong.abi.UnitType.UNIT_LENGTH_BYTES;
 public abstract class ABIType<J> {
 
     public static final int FLAGS_NONE = 0;
-    public static final int FLAG_LEGACY_ARRAY = 1;
+    public static final int FLAG_LEGACY_DECODE = 1;
     static final int FLAGS_UNSET = 0x80000000;
 
     public static final int TYPE_CODE_BOOLEAN = 0;

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
@@ -30,6 +30,9 @@ import static com.esaulpaugh.headlong.abi.UnitType.UNIT_LENGTH_BYTES;
  */
 public abstract class ABIType<J> {
 
+    public static final int FLAGS_NONE = 0;
+    public static final int FLAG_LEGACY_ARRAY = 1;
+
     public static final int TYPE_CODE_BOOLEAN = 0;
     public static final int TYPE_CODE_BYTE = 1;
     public static final int TYPE_CODE_INT = 2;
@@ -46,11 +49,17 @@ public abstract class ABIType<J> {
     final String canonicalType;
     final Class<J> clazz;
     final boolean dynamic;
+    final int flags;
 
     ABIType(String canonicalType, Class<J> clazz, boolean dynamic) {
+        this(canonicalType, clazz, dynamic, FLAGS_NONE);
+    }
+
+    ABIType(String canonicalType, Class<J> clazz, boolean dynamic, int flags) {
         this.canonicalType = canonicalType; // .intern() to save memory and allow == comparison?
         this.clazz = clazz;
         this.dynamic = dynamic;
+        this.flags = flags;
     }
 
     public final String getCanonicalType() {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
@@ -74,6 +74,10 @@ public abstract class ABIType<J> {
         return dynamic;
     }
 
+    public int getFlags() {
+        throw new UnsupportedOperationException();
+    }
+
     abstract Class<?> arrayClass();
 
     /**

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
@@ -33,6 +33,7 @@ public abstract class ABIType<J> {
     public static final int FLAGS_NONE = 0;
     /**
      * Experimental flag which enables an incompatible decode mode. Strongly consider using {@link #FLAGS_NONE} instead.
+     * Behavior is subject to change or removal in future versions.
      */
     public static final int FLAG_LEGACY_DECODE = 1;
     static final int FLAGS_UNSET = 0x80000000;

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
@@ -205,7 +205,7 @@ public abstract class ABIType<J> {
 
     public final J decodePacked(byte[] buffer) {
         return PackedDecoder.decode(
-                    new TupleType('(' + this.canonicalType + ')', dynamic, new ABIType[] { this }, null, null),
+                    new TupleType('(' + this.canonicalType + ')', dynamic, new ABIType[] { this }, null, null, this.flags),
                     buffer
                 ).get(0);
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
@@ -31,6 +31,9 @@ import static com.esaulpaugh.headlong.abi.UnitType.UNIT_LENGTH_BYTES;
 public abstract class ABIType<J> {
 
     public static final int FLAGS_NONE = 0;
+    /**
+     * Experimental flag which enables an incompatible decode mode. Strongly consider using {@link #FLAGS_NONE} instead.
+     */
     public static final int FLAG_LEGACY_DECODE = 1;
     static final int FLAGS_UNSET = 0x80000000;
 

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
@@ -208,12 +208,17 @@ public abstract class ABIType<J> {
 
     @Override
     public final int hashCode() {
-        return canonicalType.hashCode();
+        return 31 * canonicalType.hashCode() + flags;
     }
 
     @Override
     public final boolean equals(Object o) {
-        return o == this || (o instanceof ABIType && ((ABIType<?>) o).canonicalType.equals(this.canonicalType));
+        if (o == this) return true;
+        if (o instanceof ABIType) {
+            final ABIType<?> other = (ABIType<?>) o;
+            return other.canonicalType.equals(this.canonicalType) && other.flags == this.flags;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIType.java
@@ -32,6 +32,7 @@ public abstract class ABIType<J> {
 
     public static final int FLAGS_NONE = 0;
     public static final int FLAG_LEGACY_ARRAY = 1;
+    static final int FLAGS_UNSET = 0x80000000;
 
     public static final int TYPE_CODE_BOOLEAN = 0;
     public static final int TYPE_CODE_BYTE = 1;
@@ -52,7 +53,7 @@ public abstract class ABIType<J> {
     final int flags;
 
     ABIType(String canonicalType, Class<J> clazz, boolean dynamic) {
-        this(canonicalType, clazz, dynamic, FLAGS_NONE);
+        this(canonicalType, clazz, dynamic, FLAGS_UNSET);
     }
 
     ABIType(String canonicalType, Class<J> clazz, boolean dynamic, int flags) {
@@ -74,7 +75,10 @@ public abstract class ABIType<J> {
         return dynamic;
     }
 
-    public int getFlags() {
+    public final int getFlags() {
+        if (this instanceof TupleType || this instanceof ArrayType) {
+            return flags;
+        }
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
@@ -49,7 +49,7 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
     private final int length;
     private final Class<?> arrayClass;
     private final int headLength;
-    private final boolean legacy;
+    final boolean legacy;
 
     ArrayType(String canonicalType, Class<J> clazz, E elementType, int length, Class<?> arrayClass, int flags) {
         super(canonicalType, clazz, DYNAMIC_LENGTH == length || elementType.dynamic, flags);
@@ -204,11 +204,7 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
     }
 
     private int validateBytes(J arr) {
-        final int numBytes = checkLength(byteCount(arr), arr);
-        if (legacy) {
-            return numBytes;
-        }
-        return Integers.roundLengthUp(numBytes, UNIT_LENGTH_BYTES);
+        return Integers.roundLengthUp(checkLength(byteCount(arr), arr), UNIT_LENGTH_BYTES);
     }
 
     private int measureArrayElements(int n, IntUnaryOperator measurer) {
@@ -314,10 +310,8 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
     private void encodeBytes(byte[] arr, ByteBuffer dest) {
         encodeArrayLen(arr.length, dest);
         dest.put(arr);
-        if (!legacy) {
-            int rem = Integers.mod(arr.length, UNIT_LENGTH_BYTES);
-            Encoding.insert00Padding(rem != 0 ? UNIT_LENGTH_BYTES - rem : 0, dest);
-        }
+        int rem = Integers.mod(arr.length, UNIT_LENGTH_BYTES);
+        Encoding.insert00Padding(rem != 0 ? UNIT_LENGTH_BYTES - rem : 0, dest);
     }
 
     private void encodeInts(int[] arr, ByteBuffer dest) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
@@ -43,8 +43,6 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
     static final Class<String[]> STRING_ARRAY_CLASS = String[].class;
 
     public static final int DYNAMIC_LENGTH = -1;
-    static final int NO_FLAGS = 0;
-    static final int FLAG_LEGACY = 1;
 
     private final boolean isString;
     private final E elementType;
@@ -54,13 +52,13 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
     private final boolean legacy;
 
     ArrayType(String canonicalType, Class<J> clazz, E elementType, int length, Class<?> arrayClass, int flags) {
-        super(canonicalType, clazz, DYNAMIC_LENGTH == length || elementType.dynamic);
+        super(canonicalType, clazz, DYNAMIC_LENGTH == length || elementType.dynamic, flags);
         this.isString = STRING_CLASS == clazz;
         this.elementType = elementType;
         this.length = length;
         this.arrayClass = arrayClass;
         this.headLength = dynamic ? OFFSET_LENGTH_BYTES : staticArrayHeadLength();
-        this.legacy = (flags & FLAG_LEGACY) != 0;
+        this.legacy = (flags & ABIType.FLAG_LEGACY_ARRAY) != 0;
     }
 
     int staticArrayHeadLength() {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
@@ -82,6 +82,11 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
         return isString;
     }
 
+    @Override
+    public int getFlags() {
+        return flags;
+    }
+
     @SuppressWarnings("unchecked")
     private ABIType<Object> elementTypeNonCapturing() {
         return (ABIType<Object>) elementType;

--- a/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
@@ -82,11 +82,6 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
         return isString;
     }
 
-    @Override
-    public int getFlags() {
-        return flags;
-    }
-
     @SuppressWarnings("unchecked")
     private ABIType<Object> elementTypeNonCapturing() {
         return (ABIType<Object>) elementType;

--- a/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ArrayType.java
@@ -395,7 +395,6 @@ public final class ArrayType<E extends ABIType<?>, J> extends ABIType<J> {
                                                 ? arrayLen
                                                 : Integers.roundLengthUp(arrayLen, UNIT_LENGTH_BYTES);
         if(remaining < minByteLen) {
-//            System.err.println("not enough bytes remaining: " + remaining + " < " + minByteLen);
             throw new IllegalArgumentException("not enough bytes remaining: " + remaining + " < " + minByteLen);
         }
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/ContractError.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ContractError.java
@@ -72,8 +72,16 @@ public final class ContractError implements ABIObject {
         return fromJsonObject(JsonUtils.parseObject(errorJson));
     }
 
+    public static ContractError fromJson(int flags, String errorJson) {
+        return fromJsonObject(flags, JsonUtils.parseObject(errorJson));
+    }
+
     public static ContractError fromJsonObject(JsonObject error) {
         return ABIJSON.parseError(error, ABIType.FLAGS_NONE);
+    }
+
+    public static ContractError fromJsonObject(int flags, JsonObject error) {
+        return ABIJSON.parseError(error, flags);
     }
 
     @Override

--- a/src/main/java/com/esaulpaugh/headlong/abi/ContractError.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ContractError.java
@@ -72,10 +72,12 @@ public final class ContractError implements ABIObject {
         return fromJsonObject(ABIType.FLAGS_NONE, JsonUtils.parseObject(errorJson));
     }
 
+    /** @see ABIObject#fromJson(int, String) */
     public static ContractError fromJson(int flags, String errorJson) {
         return fromJsonObject(flags, JsonUtils.parseObject(errorJson));
     }
 
+    /** @see ABIObject#fromJsonObject(int, JsonObject) */
     public static ContractError fromJsonObject(int flags, JsonObject error) {
         return ABIJSON.parseError(error, flags);
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/ContractError.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ContractError.java
@@ -73,7 +73,7 @@ public final class ContractError implements ABIObject {
     }
 
     public static ContractError fromJsonObject(JsonObject error) {
-        return ABIJSON.parseError(error, ArrayType.NO_FLAGS);
+        return ABIJSON.parseError(error, ABIType.FLAGS_NONE);
     }
 
     @Override

--- a/src/main/java/com/esaulpaugh/headlong/abi/ContractError.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ContractError.java
@@ -69,15 +69,11 @@ public final class ContractError implements ABIObject {
     }
 
     public static ContractError fromJson(String errorJson) {
-        return fromJsonObject(JsonUtils.parseObject(errorJson));
+        return fromJsonObject(ABIType.FLAGS_NONE, JsonUtils.parseObject(errorJson));
     }
 
     public static ContractError fromJson(int flags, String errorJson) {
         return fromJsonObject(flags, JsonUtils.parseObject(errorJson));
-    }
-
-    public static ContractError fromJsonObject(JsonObject error) {
-        return ABIJSON.parseError(error, ABIType.FLAGS_NONE);
     }
 
     public static ContractError fromJsonObject(int flags, JsonObject error) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ContractError.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ContractError.java
@@ -73,7 +73,7 @@ public final class ContractError implements ABIObject {
     }
 
     public static ContractError fromJsonObject(JsonObject error) {
-        return ABIJSON.parseError(error);
+        return ABIJSON.parseError(error, ArrayType.NO_FLAGS);
     }
 
     @Override

--- a/src/main/java/com/esaulpaugh/headlong/abi/Event.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Event.java
@@ -121,10 +121,12 @@ public final class Event implements ABIObject {
         return fromJsonObject(ABIType.FLAGS_NONE, JsonUtils.parseObject(eventJson));
     }
 
+    /** @see ABIObject#fromJson(int, String) */
     public static Event fromJson(int flags, String eventJson) {
         return fromJsonObject(flags, JsonUtils.parseObject(eventJson));
     }
 
+    /** @see ABIObject#fromJsonObject(int, JsonObject) */
     public static Event fromJsonObject(int flags, JsonObject event) {
         return ABIJSON.parseEvent(event, flags);
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/Event.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Event.java
@@ -122,7 +122,7 @@ public final class Event implements ABIObject {
     }
 
     public static Event fromJsonObject(JsonObject event) {
-        return ABIJSON.parseEvent(event, ArrayType.NO_FLAGS);
+        return ABIJSON.parseEvent(event, ABIType.FLAGS_NONE);
     }
 
     @Override

--- a/src/main/java/com/esaulpaugh/headlong/abi/Event.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Event.java
@@ -122,7 +122,7 @@ public final class Event implements ABIObject {
     }
 
     public static Event fromJsonObject(JsonObject event) {
-        return ABIJSON.parseEvent(event);
+        return ABIJSON.parseEvent(event, ArrayType.NO_FLAGS);
     }
 
     @Override

--- a/src/main/java/com/esaulpaugh/headlong/abi/Event.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Event.java
@@ -121,8 +121,16 @@ public final class Event implements ABIObject {
         return fromJsonObject(JsonUtils.parseObject(eventJson));
     }
 
+    public static Event fromJson(int flags, String eventJson) {
+        return fromJsonObject(flags, JsonUtils.parseObject(eventJson));
+    }
+
     public static Event fromJsonObject(JsonObject event) {
         return ABIJSON.parseEvent(event, ABIType.FLAGS_NONE);
+    }
+
+    public static Event fromJsonObject(int flags, JsonObject event) {
+        return ABIJSON.parseEvent(event, flags);
     }
 
     @Override

--- a/src/main/java/com/esaulpaugh/headlong/abi/Event.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Event.java
@@ -118,15 +118,11 @@ public final class Event implements ABIObject {
     }
 
     public static Event fromJson(String eventJson) {
-        return fromJsonObject(JsonUtils.parseObject(eventJson));
+        return fromJsonObject(ABIType.FLAGS_NONE, JsonUtils.parseObject(eventJson));
     }
 
     public static Event fromJson(int flags, String eventJson) {
         return fromJsonObject(flags, JsonUtils.parseObject(eventJson));
-    }
-
-    public static Event fromJsonObject(JsonObject event) {
-        return ABIJSON.parseEvent(event, ABIType.FLAGS_NONE);
     }
 
     public static Event fromJsonObject(int flags, JsonObject event) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/Function.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Function.java
@@ -347,18 +347,18 @@ public final class Function implements ABIObject {
     }
 
     public static Function fromJson(String objectJson) {
-        return fromJsonObject(JsonUtils.parseObject(objectJson), ABIType.FLAGS_NONE);
+        return fromJsonObject(ABIType.FLAGS_NONE, JsonUtils.parseObject(objectJson));
     }
 
-    public static Function fromJson(String objectJson, int flags) {
-        return fromJsonObject(JsonUtils.parseObject(objectJson), flags);
+    public static Function fromJson(int flags, String objectJson) {
+        return fromJsonObject(flags, JsonUtils.parseObject(objectJson));
     }
 
-    public static Function fromJsonObject(JsonObject function, int flags) {
-        return fromJsonObject(function, Function.newDefaultDigest(), flags);
+    public static Function fromJsonObject(int flags, JsonObject function) {
+        return fromJsonObject(flags, function, Function.newDefaultDigest());
     }
 
-    public static Function fromJsonObject(JsonObject function, MessageDigest digest, int flags) {
+    public static Function fromJsonObject(int flags, JsonObject function, MessageDigest digest) {
         return ABIJSON.parseFunction(function, digest, flags);
     }
 

--- a/src/main/java/com/esaulpaugh/headlong/abi/Function.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Function.java
@@ -56,11 +56,11 @@ public final class Function implements ABIObject {
     private final int flags;
 
     public Function(String signature) {
-        this(signature, signature.indexOf('('), TupleType.EMPTY, ArrayType.NO_FLAGS);
+        this(signature, signature.indexOf('('), TupleType.EMPTY, ABIType.FLAGS_NONE);
     }
 
     public Function(String signature, String outputs) {
-        this(signature, outputs, ArrayType.NO_FLAGS);
+        this(signature, outputs, ABIType.FLAGS_NONE);
     }
 
     private Function(String signature, String outputs, int flags) {
@@ -81,7 +81,7 @@ public final class Function implements ABIObject {
 
 
     public Function(TypeEnum type, String name, TupleType inputs, TupleType outputs, String stateMutability, MessageDigest messageDigest) {
-        this(type, name, inputs, outputs, stateMutability, messageDigest, ArrayType.NO_FLAGS);
+        this(type, name, inputs, outputs, stateMutability, messageDigest, ABIType.FLAGS_NONE);
     }
 
     /**
@@ -91,7 +91,7 @@ public final class Function implements ABIObject {
      * @param outputs       {@link TupleType} type describing this function's return types
      * @param stateMutability   "pure", "view", "payable" etc.
      * @param messageDigest hash function with which to generate the 4-byte selector
-     * @param flags options such as {@link ArrayType#FLAG_LEGACY} or {@link ArrayType#NO_FLAGS}
+     * @param flags options such as {@link ABIType#FLAG_LEGACY_ARRAY} or {@link ABIType#FLAGS_NONE}
      * @throws IllegalArgumentException if the arguments do not specify a valid function
      */
     public Function(TypeEnum type, String name, TupleType inputs, TupleType outputs, String stateMutability, MessageDigest messageDigest, int flags) {
@@ -356,7 +356,7 @@ public final class Function implements ABIObject {
     }
 
     public static Function fromJson(String objectJson) {
-        return fromJsonObject(JsonUtils.parseObject(objectJson), ArrayType.NO_FLAGS);
+        return fromJsonObject(JsonUtils.parseObject(objectJson), ABIType.FLAGS_NONE);
     }
 
     public static Function fromJson(String objectJson, int flags) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/Function.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Function.java
@@ -350,10 +350,12 @@ public final class Function implements ABIObject {
         return fromJsonObject(ABIType.FLAGS_NONE, JsonUtils.parseObject(objectJson));
     }
 
+    /** @see ABIObject#fromJson(int, String) */
     public static Function fromJson(int flags, String objectJson) {
         return fromJsonObject(flags, JsonUtils.parseObject(objectJson));
     }
 
+    /** @see ABIObject#fromJsonObject(int, JsonObject) */
     public static Function fromJsonObject(int flags, JsonObject function) {
         return fromJsonObject(flags, function, Function.newDefaultDigest());
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/Function.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Function.java
@@ -73,14 +73,8 @@ public final class Function implements ABIObject {
                 TupleType.parse(signature.substring(nameLength), flags),
                 outputs,
                 null,
-                Function.newDefaultDigest(),
-                flags
+                Function.newDefaultDigest()
         );
-    }
-
-
-    public Function(TypeEnum type, String name, TupleType inputs, TupleType outputs, String stateMutability, MessageDigest messageDigest) {
-        this(type, name, inputs, outputs, stateMutability, messageDigest, ABIType.FLAGS_NONE);
     }
 
     /**
@@ -90,10 +84,9 @@ public final class Function implements ABIObject {
      * @param outputs       {@link TupleType} type describing this function's return types
      * @param stateMutability   "pure", "view", "payable" etc.
      * @param messageDigest hash function with which to generate the 4-byte selector
-     * @param flags options such as {@link ABIType#FLAG_LEGACY_ARRAY} or {@link ABIType#FLAGS_NONE}
      * @throws IllegalArgumentException if the arguments do not specify a valid function
      */
-    public Function(TypeEnum type, String name, TupleType inputs, TupleType outputs, String stateMutability, MessageDigest messageDigest, int flags) {
+    public Function(TypeEnum type, String name, TupleType inputs, TupleType outputs, String stateMutability, MessageDigest messageDigest) {
         this.type = Objects.requireNonNull(type);
         this.name = name != null ? validateName(name) : null;
         this.inputTypes = Objects.requireNonNull(inputs);

--- a/src/main/java/com/esaulpaugh/headlong/abi/Function.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Function.java
@@ -63,7 +63,7 @@ public final class Function implements ABIObject {
     }
 
     private Function(int flags, String signature, String outputs) {
-        this(signature, signature.indexOf('('), outputs != null ? TupleType.parse(flags, outputs) : TupleType.EMPTY, flags);
+        this(signature, signature.indexOf('('), outputs != null ? TupleType.parse(flags, outputs) : TupleType.empty(flags), flags);
     }
 
     private Function(final String signature, final int nameLength, final TupleType outputs, final int flags) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/Function.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Function.java
@@ -53,7 +53,6 @@ public final class Function implements ABIObject {
 
     private final String hashAlgorithm;
     private final byte[] selector = new byte[SELECTOR_LEN];
-    private final int flags;
 
     public Function(String signature) {
         this(signature, signature.indexOf('('), TupleType.EMPTY, ABIType.FLAGS_NONE);
@@ -101,7 +100,6 @@ public final class Function implements ABIObject {
         this.outputTypes = Objects.requireNonNull(outputs);
         this.stateMutability = stateMutability;
         this.hashAlgorithm = Objects.requireNonNull(messageDigest.getAlgorithm());
-        this.flags = flags;
         validateFunction();
         generateSelector(messageDigest);
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/Function.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/Function.java
@@ -59,18 +59,18 @@ public final class Function implements ABIObject {
     }
 
     public Function(String signature, String outputs) {
-        this(signature, outputs, ABIType.FLAGS_NONE);
+        this(ABIType.FLAGS_NONE, signature, outputs);
     }
 
-    private Function(String signature, String outputs, int flags) {
-        this(signature, signature.indexOf('('), outputs != null ? TupleType.parse(outputs, flags) : TupleType.EMPTY, flags);
+    private Function(int flags, String signature, String outputs) {
+        this(signature, signature.indexOf('('), outputs != null ? TupleType.parse(flags, outputs) : TupleType.EMPTY, flags);
     }
 
     private Function(final String signature, final int nameLength, final TupleType outputs, final int flags) {
         this(
                 TypeEnum.FUNCTION,
                 signature.substring(0, nameLength),
-                TupleType.parse(signature.substring(nameLength), flags),
+                TupleType.parse(flags, signature.substring(nameLength)),
                 outputs,
                 null,
                 Function.newDefaultDigest()
@@ -342,8 +342,8 @@ public final class Function implements ABIObject {
         return new Function(signature, outputs);
     }
 
-    public static Function parse(String signature, String outputs, int flags) {
-        return new Function(signature, outputs, flags);
+    public static Function parse(int flags, String signature, String outputs) {
+        return new Function(flags, signature, outputs);
     }
 
     public static Function fromJson(String objectJson) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
@@ -406,8 +406,8 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
         return TypeFactory.create(rawTupleTypeString);
     }
 
-    public static TupleType parse(String rawTupleTypeString, int flags) {
-        return TypeFactory.create(rawTupleTypeString, flags);
+    public static TupleType parse(int flags, String rawTupleTypeString) {
+        return TypeFactory.create(flags, rawTupleTypeString);
     }
 
     public static TupleType of(String... typeStrings) {
@@ -416,5 +416,9 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
             sb.append(str).append(',');
         }
         return parse(completeTupleTypeString(sb));
+    }
+
+    static TupleType empty(int flags) {
+        return flags == ABIType.FLAGS_NONE ? EMPTY : new TupleType(EMPTY_TUPLE_STRING, false, EMPTY_ARRAY, null, null, flags);
     }
 }

--- a/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
@@ -70,16 +70,10 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
     }
 
     public String getElementName(int index) {
-        if(index < 0 || index >= size()) {
-            throw new IllegalArgumentException("index out of bounds: " + index);
-        }
         return elementNames == null ? null : elementNames[index];
     }
 
     public String getElementInternalType(int index) {
-        if(index < 0 || index >= size()) {
-            throw new IllegalArgumentException("index out of bounds: " + index);
-        }
         return elementInternalTypes == null ? null : elementInternalTypes[index];
     }
 

--- a/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
@@ -405,6 +405,10 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
         return TypeFactory.create(rawTupleTypeString);
     }
 
+    public static TupleType parse(String rawTupleTypeString, int flags) {
+        return TypeFactory.create(rawTupleTypeString, flags);
+    }
+
     public static TupleType of(String... typeStrings) {
         StringBuilder sb = new StringBuilder("(");
         for (String str : typeStrings) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TupleType.java
@@ -32,7 +32,7 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
     static final String EMPTY_TUPLE_STRING = "()";
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
-    public static final TupleType EMPTY = new TupleType(EMPTY_TUPLE_STRING, false, EMPTY_ARRAY, null, null);
+    public static final TupleType EMPTY = new TupleType(EMPTY_TUPLE_STRING, false, EMPTY_ARRAY, null, null, ABIType.FLAGS_NONE);
 
     final ABIType<?>[] elementTypes;
     final String[] elementNames;
@@ -41,8 +41,8 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
     private final int headLength;
     private final int firstOffset;
 
-    TupleType(String canonicalType, boolean dynamic, ABIType<?>[] elementTypes, String[] elementNames, String[] elementInternalTypes) {
-        super(canonicalType, Tuple.class, dynamic);
+    TupleType(String canonicalType, boolean dynamic, ABIType<?>[] elementTypes, String[] elementNames, String[] elementInternalTypes, int flags) {
+        super(canonicalType, Tuple.class, dynamic, flags);
         this.elementTypes = elementTypes;
         this.elementNames = elementNames;
         this.elementInternalTypes = elementInternalTypes;
@@ -243,7 +243,7 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
                 final int offset = offsets[i];
                 if (offset != 0) {
                     final int jump = start + offset;
-                    if (jump != bb.position()) {
+                    if (jump != bb.position()) { // && (this.flags & ABIType.FLAG_LEGACY_ARRAY) == 0
                         /* LENIENT MODE; see https://github.com/ethereum/solidity/commit/3d1ca07e9b4b42355aa9be5db5c00048607986d1 */
                         bb.position(offset == -1 ? start : jump); // leniently jump to specified offset
                     }
@@ -388,7 +388,8 @@ public final class TupleType extends ABIType<Tuple> implements Iterable<ABIType<
                     dynamic,
                     selected.toArray(EMPTY_ARRAY),
                     selectedNames == null ? null : selectedNames.toArray(EMPTY_STRING_ARRAY),
-                    selectedInternalTypes == null ? null : selectedInternalTypes.toArray(EMPTY_STRING_ARRAY)
+                    selectedInternalTypes == null ? null : selectedInternalTypes.toArray(EMPTY_STRING_ARRAY),
+                    this.flags
             );
         }
         throw new IllegalArgumentException("manifest.length != size(): " + manifest.length + " != " + size);

--- a/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
@@ -117,11 +117,11 @@ public final class TypeFactory {
         return new ArrayType<ByteType, byte[]>(type, byte[].class, ByteType.INSTANCE, arrayLen, byte[][].class, flags);
     }
 
-    @SuppressWarnings("unchecked")
     public static <T extends ABIType<?>> T create(String rawType) {
         return create(rawType, ABIType.FLAGS_NONE);
     }
 
+    @SuppressWarnings("unchecked")
     public static <T extends ABIType<?>> T create(String rawType, int flags) {
         return (T) build(rawType, null, null, flags);
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
@@ -87,7 +87,7 @@ public final class TypeFactory {
             ABIType<?> value = e.getValue();
             if (value instanceof ArrayType) {
                 final ArrayType<?, ?> at = (ArrayType<?, ?>) value;
-                value = newArrayType(at.canonicalType, at.getLength(), ABIType.FLAG_LEGACY_ARRAY);
+                value = new ArrayType<ByteType, byte[]>(at.canonicalType, byte[].class, ByteType.INSTANCE, at.getLength(), byte[][].class, ABIType.FLAG_LEGACY_ARRAY);
             }
             LEGACY_BASE_TYPE_MAP.put(e.getKey(), value);
         }
@@ -110,11 +110,7 @@ public final class TypeFactory {
     }
 
     private static void mapByteArray(String type, int arrayLen) {
-        BASE_TYPE_MAP.put(type, newArrayType(type, arrayLen, ABIType.FLAGS_NONE));
-    }
-
-    private static ArrayType<?, ?> newArrayType(String type, int arrayLen, int flags) {
-        return new ArrayType<ByteType, byte[]>(type, byte[].class, ByteType.INSTANCE, arrayLen, byte[][].class, flags);
+        BASE_TYPE_MAP.put(type, new ArrayType<ByteType, byte[]>(type, byte[].class, ByteType.INSTANCE, arrayLen, byte[][].class, ABIType.FLAGS_NONE));
     }
 
     public static <T extends ABIType<?>> T create(String rawType) {
@@ -251,7 +247,8 @@ public final class TypeFactory {
                     dynamic,
                     elements.toArray(EMPTY_ARRAY),
                     elementNames,
-                    null
+                    null,
+                    flags
                 )
                 : null;
     }

--- a/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
@@ -67,7 +67,7 @@ public final class TypeFactory {
         BASE_TYPE_MAP.put("address", new AddressType());
         mapByteArray("function", FUNCTION_BYTE_LEN);
         mapByteArray("bytes", DYNAMIC_LENGTH);
-        BASE_TYPE_MAP.put("string", new ArrayType<ByteType, String>("string", STRING_CLASS, ByteType.INSTANCE, DYNAMIC_LENGTH, STRING_ARRAY_CLASS, ArrayType.NO_FLAGS));
+        BASE_TYPE_MAP.put("string", new ArrayType<ByteType, String>("string", STRING_CLASS, ByteType.INSTANCE, DYNAMIC_LENGTH, STRING_ARRAY_CLASS, ABIType.FLAGS_NONE));
 
         BASE_TYPE_MAP.put("fixed128x18", new BigDecimalType("fixed128x18", FIXED_BIT_LEN, FIXED_SCALE, false));
         BASE_TYPE_MAP.put("ufixed128x18", new BigDecimalType("ufixed128x18", FIXED_BIT_LEN, FIXED_SCALE, true));
@@ -87,7 +87,7 @@ public final class TypeFactory {
             ABIType<?> value = e.getValue();
             if (value instanceof ArrayType) {
                 final ArrayType<?, ?> at = (ArrayType<?, ?>) value;
-                value = newArrayType(at.canonicalType, at.getLength(), ArrayType.FLAG_LEGACY);
+                value = newArrayType(at.canonicalType, at.getLength(), ABIType.FLAG_LEGACY_ARRAY);
             }
             LEGACY_BASE_TYPE_MAP.put(e.getKey(), value);
         }
@@ -110,7 +110,7 @@ public final class TypeFactory {
     }
 
     private static void mapByteArray(String type, int arrayLen) {
-        BASE_TYPE_MAP.put(type, newArrayType(type, arrayLen, ArrayType.NO_FLAGS));
+        BASE_TYPE_MAP.put(type, newArrayType(type, arrayLen, ABIType.FLAGS_NONE));
     }
 
     private static ArrayType<?, ?> newArrayType(String type, int arrayLen, int flags) {
@@ -119,7 +119,7 @@ public final class TypeFactory {
 
     @SuppressWarnings("unchecked")
     public static <T extends ABIType<?>> T create(String rawType) {
-        return create(rawType, ArrayType.NO_FLAGS);
+        return create(rawType, ABIType.FLAGS_NONE);
     }
 
     public static <T extends ABIType<?>> T create(String rawType, int flags) {
@@ -128,12 +128,12 @@ public final class TypeFactory {
 
     @SuppressWarnings("unchecked")
     public static ABIType<Object> createNonCapturing(String rawType) {
-        return (ABIType<Object>) build(rawType, null, null, ArrayType.NO_FLAGS);
+        return (ABIType<Object>) build(rawType, null, null, ABIType.FLAGS_NONE);
     }
 
     /** If you don't need any {@code elementNames}, use {@link TypeFactory#create(String)}. */
     public static TupleType createTupleTypeWithNames(String rawType, String... elementNames) {
-        return (TupleType) build(rawType, elementNames, null, ArrayType.NO_FLAGS);
+        return (TupleType) build(rawType, elementNames, null, ABIType.FLAGS_NONE);
     }
 
     static ABIType<?> build(String rawType, String[] elementNames, ABIType<?> baseType, int flags) {
@@ -184,7 +184,7 @@ public final class TypeFactory {
             return parseTupleType(baseTypeStr, elementNames, flags);
         }
         final ABIType<?> ret;
-        if ((flags & ArrayType.FLAG_LEGACY) != 0) {
+        if ((flags & ABIType.FLAG_LEGACY_ARRAY) != 0) {
             ret = LEGACY_BASE_TYPE_MAP.get(baseTypeStr);
         } else {
             ret = BASE_TYPE_MAP.get(baseTypeStr);

--- a/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
@@ -87,7 +87,11 @@ public final class TypeFactory {
             ABIType<?> value = e.getValue();
             if (value instanceof ArrayType) {
                 final ArrayType<?, ?> at = (ArrayType<?, ?>) value;
-                value = new ArrayType<ByteType, byte[]>(at.canonicalType, byte[].class, ByteType.INSTANCE, at.getLength(), byte[][].class, ABIType.FLAG_LEGACY_DECODE);
+                if (at.isString()) {
+                    value = new ArrayType<ByteType, String>("string", STRING_CLASS, ByteType.INSTANCE, DYNAMIC_LENGTH, STRING_ARRAY_CLASS, ABIType.FLAG_LEGACY_DECODE);
+                } else {
+                    value = new ArrayType<ByteType, byte[]>(at.canonicalType, byte[].class, ByteType.INSTANCE, at.getLength(), byte[][].class, ABIType.FLAG_LEGACY_DECODE);
+                }
             }
             LEGACY_BASE_TYPE_MAP.put(e.getKey(), value);
         }

--- a/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
@@ -114,11 +114,11 @@ public final class TypeFactory {
     }
 
     public static <T extends ABIType<?>> T create(String rawType) {
-        return create(rawType, ABIType.FLAGS_NONE);
+        return create(ABIType.FLAGS_NONE, rawType);
     }
 
     @SuppressWarnings("unchecked")
-    public static <T extends ABIType<?>> T create(String rawType, int flags) {
+    public static <T extends ABIType<?>> T create(int flags, String rawType) {
         return (T) build(rawType, null, null, flags);
     }
 
@@ -216,7 +216,7 @@ public final class TypeFactory {
 
     private static TupleType parseTupleType(final String rawTypeStr, final String[] elementNames, final int flags) { /* assumes that rawTypeStr.charAt(0) == '(' */
         final int len = rawTypeStr.length();
-        if (len == 2 && rawTypeStr.equals(EMPTY_TUPLE_STRING)) return TupleType.EMPTY;
+        if (len == 2 && rawTypeStr.equals(EMPTY_TUPLE_STRING)) return TupleType.empty(flags);
         final List<ABIType<?>> elements = new ArrayList<>();
         int argEnd = 1;
         final StringBuilder canonicalBuilder = new StringBuilder("(");

--- a/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/TypeFactory.java
@@ -87,7 +87,7 @@ public final class TypeFactory {
             ABIType<?> value = e.getValue();
             if (value instanceof ArrayType) {
                 final ArrayType<?, ?> at = (ArrayType<?, ?>) value;
-                value = new ArrayType<ByteType, byte[]>(at.canonicalType, byte[].class, ByteType.INSTANCE, at.getLength(), byte[][].class, ABIType.FLAG_LEGACY_ARRAY);
+                value = new ArrayType<ByteType, byte[]>(at.canonicalType, byte[].class, ByteType.INSTANCE, at.getLength(), byte[][].class, ABIType.FLAG_LEGACY_DECODE);
             }
             LEGACY_BASE_TYPE_MAP.put(e.getKey(), value);
         }
@@ -180,7 +180,7 @@ public final class TypeFactory {
             return parseTupleType(baseTypeStr, elementNames, flags);
         }
         final ABIType<?> ret;
-        if ((flags & ABIType.FLAG_LEGACY_ARRAY) != 0) {
+        if ((flags & ABIType.FLAG_LEGACY_DECODE) != 0) {
             ret = LEGACY_BASE_TYPE_MAP.get(baseTypeStr);
         } else {
             ret = BASE_TYPE_MAP.get(baseTypeStr);

--- a/src/main/java/com/esaulpaugh/headlong/util/Integers.java
+++ b/src/main/java/com/esaulpaugh/headlong/util/Integers.java
@@ -467,8 +467,7 @@ public final class Integers {
      * @return the rounded-up value
      */
     public static int roundLengthUp(int len, int powerOfTwo) {
-        int mod = mod(len, powerOfTwo);
-        return mod != 0 ? len + (powerOfTwo - mod) : len;
+        return -powerOfTwo & (len + (powerOfTwo - 1));
     }
 
     public static boolean isMultiple(int val, int powerOfTwo) {

--- a/src/test/java/com/esaulpaugh/headlong/TestUtils.java
+++ b/src/test/java/com/esaulpaugh/headlong/TestUtils.java
@@ -454,4 +454,11 @@ public class TestUtils {
     public static String toPrettyPrint(JsonElement element) {
         return new GsonBuilder().setPrettyPrinting().create().toJson(element);
     }
+
+    public static String completeTupleTypeString(StringBuilder sb) {
+        final int len = sb.length();
+        return len != 1
+                ? sb.deleteCharAt(len - 1).append(')').toString() // replace trailing comma
+                : "()";
+    }
 }

--- a/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
@@ -264,15 +264,15 @@ public class ABIJSONTest {
         }
 
         for (String originalJson : jsons) {
-            ABIObject orig = ABIObject.fromJsonObject(JsonUtils.parseObject(originalJson), ABIType.FLAGS_NONE);
+            ABIObject orig = ABIObject.fromJsonObject(JsonUtils.parseObject(originalJson));
             String newJson = orig.toJson(false);
             assertNotEquals(originalJson, newJson);
 
-            ABIObject reconstructed = ABIObject.fromJsonObject(JsonUtils.parseObject(newJson), ABIType.FLAGS_NONE);
+            ABIObject reconstructed = ABIObject.fromJsonObject(JsonUtils.parseObject(newJson));
 
             assertEquals(orig, reconstructed);
             assertEquals(originalJson, reconstructed.toString());
-            assertEquals(orig, ABIObject.fromJson(newJson, ABIType.FLAGS_NONE));
+            assertEquals(orig, ABIObject.fromJson(newJson));
         }
     }
 
@@ -308,9 +308,9 @@ public class ABIJSONTest {
         printTupleType(in);
         printTupleType(out);
 
-        Function f2 = ABIObject.fromJson(FUNCTION_A_JSON, ABIType.FLAGS_NONE);
+        Function f2 = ABIObject.fromJson(FUNCTION_A_JSON);
         assertEquals(f, f2);
-        assertEquals(f, ABIObject.fromJsonObject(object, ABIType.FLAGS_NONE));
+        assertEquals(f, ABIObject.fromJsonObject(object));
 
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", f2::asContractError);
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Event", f2::asEvent);
@@ -395,9 +395,9 @@ public class ABIJSONTest {
         String json = jsonObject.toString();
         assertEquals(expectedA, Event.fromJson(json));
 
-        Event e = ABIObject.fromJson(json, ABIType.FLAGS_NONE);
+        Event e = ABIObject.fromJson(json);
         assertEquals(expectedA, e);
-        assertEquals(e, ABIObject.fromJsonObject(jsonObject, ABIType.FLAGS_NONE));
+        assertEquals(e, ABIObject.fromJsonObject(jsonObject));
 
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", e::asContractError);
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Function", e::asFunction);
@@ -541,7 +541,7 @@ public class ABIJSONTest {
         JsonObject object = JsonUtils.parseObject(ERROR_JSON);
 
         ContractError error0 = ABIJSON.parseErrors(ERROR_JSON_ARRAY).get(0);
-        ContractError error1 = ABIObject.fromJsonObject(object, ABIType.FLAGS_NONE);
+        ContractError error1 = ABIObject.fromJsonObject(object);
 
         testError(error0, ERROR_JSON, object);
         testError(error1, ERROR_JSON, object);
@@ -563,8 +563,8 @@ public class ABIJSONTest {
 
         testEqualNotSame(error, ContractError.fromJson(json));
         testEqualNotSame(error, ContractError.fromJsonObject(object));
-        testEqualNotSame(error, ABIObject.fromJson(json, ABIType.FLAGS_NONE));
-        testEqualNotSame(error, ABIObject.fromJsonObject(object, ABIType.FLAGS_NONE));
+        testEqualNotSame(error, ABIObject.fromJson(json));
+        testEqualNotSame(error, ABIObject.fromJsonObject(object));
 
         assertFalse(error.isFunction());
         assertFalse(error.isEvent());

--- a/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
@@ -264,11 +264,11 @@ public class ABIJSONTest {
         }
 
         for (String originalJson : jsons) {
-            ABIObject orig = ABIObject.fromJsonObject(JsonUtils.parseObject(originalJson));
+            ABIObject orig = ABIObject.fromJsonObject(ABIType.FLAGS_NONE, JsonUtils.parseObject(originalJson));
             String newJson = orig.toJson(false);
             assertNotEquals(originalJson, newJson);
 
-            ABIObject reconstructed = ABIObject.fromJsonObject(JsonUtils.parseObject(newJson));
+            ABIObject reconstructed = ABIObject.fromJsonObject(ABIType.FLAGS_NONE, JsonUtils.parseObject(newJson));
 
             assertEquals(orig, reconstructed);
             assertEquals(originalJson, reconstructed.toString());
@@ -310,7 +310,7 @@ public class ABIJSONTest {
 
         Function f2 = ABIObject.fromJson(FUNCTION_A_JSON);
         assertEquals(f, f2);
-        assertEquals(f, ABIObject.fromJsonObject(object));
+        assertEquals(f, ABIObject.fromJsonObject(ABIType.FLAGS_NONE, object));
 
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", f2::asContractError);
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Event", f2::asEvent);
@@ -371,7 +371,7 @@ public class ABIJSONTest {
     public void testParseEvent() throws Throwable {
         JsonObject jsonObject = new JsonObject();
 
-        TestUtils.CustomRunnable runnable = () -> Event.fromJsonObject(jsonObject);
+        TestUtils.CustomRunnable runnable = () -> Event.fromJsonObject(ABIType.FLAGS_NONE, jsonObject);
 
         TestUtils.assertThrown(IllegalArgumentException.class, "unexpected type: null", runnable);
 
@@ -397,7 +397,7 @@ public class ABIJSONTest {
 
         Event e = ABIObject.fromJson(json);
         assertEquals(expectedA, e);
-        assertEquals(e, ABIObject.fromJsonObject(jsonObject));
+        assertEquals(e, ABIObject.fromJsonObject(ABIType.FLAGS_NONE, jsonObject));
 
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", e::asContractError);
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Function", e::asFunction);
@@ -541,7 +541,7 @@ public class ABIJSONTest {
         JsonObject object = JsonUtils.parseObject(ERROR_JSON);
 
         ContractError error0 = ABIJSON.parseErrors(ERROR_JSON_ARRAY).get(0);
-        ContractError error1 = ABIObject.fromJsonObject(object);
+        ContractError error1 = ABIObject.fromJsonObject(ABIType.FLAGS_NONE, object);
 
         testError(error0, ERROR_JSON, object);
         testError(error1, ERROR_JSON, object);
@@ -562,9 +562,9 @@ public class ABIJSONTest {
         assertEquals(json, error.toString());
 
         testEqualNotSame(error, ContractError.fromJson(json));
-        testEqualNotSame(error, ContractError.fromJsonObject(object));
+        testEqualNotSame(error, ContractError.fromJsonObject(ABIType.FLAGS_NONE, object));
         testEqualNotSame(error, ABIObject.fromJson(json));
-        testEqualNotSame(error, ABIObject.fromJsonObject(object));
+        testEqualNotSame(error, ABIObject.fromJsonObject(ABIType.FLAGS_NONE, object));
 
         assertFalse(error.isFunction());
         assertFalse(error.isEvent());

--- a/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
@@ -264,22 +264,22 @@ public class ABIJSONTest {
         }
 
         for (String originalJson : jsons) {
-            ABIObject orig = ABIObject.fromJsonObject(JsonUtils.parseObject(originalJson), ArrayType.NO_FLAGS);
+            ABIObject orig = ABIObject.fromJsonObject(JsonUtils.parseObject(originalJson), ABIType.FLAGS_NONE);
             String newJson = orig.toJson(false);
             assertNotEquals(originalJson, newJson);
 
-            ABIObject reconstructed = ABIObject.fromJsonObject(JsonUtils.parseObject(newJson), ArrayType.NO_FLAGS);
+            ABIObject reconstructed = ABIObject.fromJsonObject(JsonUtils.parseObject(newJson), ABIType.FLAGS_NONE);
 
             assertEquals(orig, reconstructed);
             assertEquals(originalJson, reconstructed.toString());
-            assertEquals(orig, ABIObject.fromJson(newJson, ArrayType.NO_FLAGS));
+            assertEquals(orig, ABIObject.fromJson(newJson, ABIType.FLAGS_NONE));
         }
     }
 
     @Test
     public void testParseFunctionA() throws Throwable {
         final JsonObject object = JsonUtils.parseObject(FUNCTION_A_JSON);
-        final Function f = Function.fromJsonObject(object, ArrayType.NO_FLAGS);
+        final Function f = Function.fromJsonObject(object, ABIType.FLAGS_NONE);
         assertEquals(FUNCTION_A_JSON, f.toJson(true));
         final TupleType in = f.getInputs();
         final TupleType out = f.getOutputs();
@@ -308,9 +308,9 @@ public class ABIJSONTest {
         printTupleType(in);
         printTupleType(out);
 
-        Function f2 = ABIObject.fromJson(FUNCTION_A_JSON, ArrayType.NO_FLAGS);
+        Function f2 = ABIObject.fromJson(FUNCTION_A_JSON, ABIType.FLAGS_NONE);
         assertEquals(f, f2);
-        assertEquals(f, ABIObject.fromJsonObject(object, ArrayType.NO_FLAGS));
+        assertEquals(f, ABIObject.fromJsonObject(object, ABIType.FLAGS_NONE));
 
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", f2::asContractError);
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Event", f2::asEvent);
@@ -338,7 +338,7 @@ public class ABIJSONTest {
     public void testParseFunction2() throws Throwable {
         final JsonObject function = new JsonObject();
 
-        TestUtils.CustomRunnable parse = () -> Function.fromJsonObject(function, ArrayType.NO_FLAGS);
+        TestUtils.CustomRunnable parse = () -> Function.fromJsonObject(function, ABIType.FLAGS_NONE);
 
         TestUtils.assertThrown(IllegalArgumentException.class, "type is \"function\"; functions of this type must define name", parse);
 
@@ -395,9 +395,9 @@ public class ABIJSONTest {
         String json = jsonObject.toString();
         assertEquals(expectedA, Event.fromJson(json));
 
-        Event e = ABIObject.fromJson(json, ArrayType.NO_FLAGS);
+        Event e = ABIObject.fromJson(json, ABIType.FLAGS_NONE);
         assertEquals(expectedA, e);
-        assertEquals(e, ABIObject.fromJsonObject(jsonObject, ArrayType.NO_FLAGS));
+        assertEquals(e, ABIObject.fromJsonObject(jsonObject, ABIType.FLAGS_NONE));
 
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", e::asContractError);
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Function", e::asFunction);
@@ -541,7 +541,7 @@ public class ABIJSONTest {
         JsonObject object = JsonUtils.parseObject(ERROR_JSON);
 
         ContractError error0 = ABIJSON.parseErrors(ERROR_JSON_ARRAY).get(0);
-        ContractError error1 = ABIObject.fromJsonObject(object, ArrayType.NO_FLAGS);
+        ContractError error1 = ABIObject.fromJsonObject(object, ABIType.FLAGS_NONE);
 
         testError(error0, ERROR_JSON, object);
         testError(error1, ERROR_JSON, object);
@@ -563,8 +563,8 @@ public class ABIJSONTest {
 
         testEqualNotSame(error, ContractError.fromJson(json));
         testEqualNotSame(error, ContractError.fromJsonObject(object));
-        testEqualNotSame(error, ABIObject.fromJson(json, ArrayType.NO_FLAGS));
-        testEqualNotSame(error, ABIObject.fromJsonObject(object, ArrayType.NO_FLAGS));
+        testEqualNotSame(error, ABIObject.fromJson(json, ABIType.FLAGS_NONE));
+        testEqualNotSame(error, ABIObject.fromJsonObject(object, ABIType.FLAGS_NONE));
 
         assertFalse(error.isFunction());
         assertFalse(error.isEvent());

--- a/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static com.esaulpaugh.headlong.TestUtils.assertThrown;
 import static com.esaulpaugh.headlong.abi.ABIType.TYPE_CODE_ARRAY;
 import static com.esaulpaugh.headlong.abi.ABIType.TYPE_CODE_TUPLE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -312,8 +313,8 @@ public class ABIJSONTest {
         assertEquals(f, f2);
         assertEquals(f, ABIObject.fromJsonObject(ABIType.FLAGS_NONE, object));
 
-        TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", f2::asContractError);
-        TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Event", f2::asEvent);
+        assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", f2::asContractError);
+        assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Event", f2::asEvent);
 
         assertTrue(f.isFunction());
         assertFalse(f.isEvent());
@@ -340,15 +341,15 @@ public class ABIJSONTest {
 
         TestUtils.CustomRunnable parse = () -> Function.fromJsonObject(ABIType.FLAGS_NONE, function);
 
-        TestUtils.assertThrown(IllegalArgumentException.class, "type is \"function\"; functions of this type must define name", parse);
+        assertThrown(IllegalArgumentException.class, "type is \"function\"; functions of this type must define name", parse);
 
         function.add("type", new JsonPrimitive("event"));
 
-        TestUtils.assertThrown(IllegalArgumentException.class, "unexpected type: \"event\"", parse);
+        assertThrown(IllegalArgumentException.class, "unexpected type: \"event\"", parse);
 
         function.add("type", new JsonPrimitive("function"));
 
-        TestUtils.assertThrown(IllegalArgumentException.class, "type is \"function\"; functions of this type must define name", parse);
+        assertThrown(IllegalArgumentException.class, "type is \"function\"; functions of this type must define name", parse);
 
         TestUtils.CustomRunnable[] updates = new TestUtils.CustomRunnable[] {
                 () -> function.add("type", new JsonPrimitive("fallback")),
@@ -373,15 +374,15 @@ public class ABIJSONTest {
 
         TestUtils.CustomRunnable runnable = () -> Event.fromJsonObject(ABIType.FLAGS_NONE, jsonObject);
 
-        TestUtils.assertThrown(IllegalArgumentException.class, "unexpected type: null", runnable);
+        assertThrown(IllegalArgumentException.class, "unexpected type: null", runnable);
 
         jsonObject.add("type", new JsonPrimitive("event"));
 
-        TestUtils.assertThrown(IllegalArgumentException.class, "array \"inputs\" null or not found", runnable);
+        assertThrown(IllegalArgumentException.class, "array \"inputs\" null or not found", runnable);
 
         jsonObject.add("inputs", new JsonArray());
 
-        TestUtils.assertThrown(NullPointerException.class, runnable);
+        assertThrown(NullPointerException.class, runnable);
 
         jsonObject.add("name", new JsonPrimitive("a_name"));
 
@@ -399,8 +400,8 @@ public class ABIJSONTest {
         assertEquals(expectedA, e);
         assertEquals(e, ABIObject.fromJsonObject(ABIType.FLAGS_NONE, jsonObject));
 
-        TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", e::asContractError);
-        TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Function", e::asFunction);
+        assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", e::asContractError);
+        assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Function", e::asFunction);
 
         assertFalse(e.isFunction());
         assertTrue(e.isEvent());
@@ -548,8 +549,8 @@ public class ABIJSONTest {
 
         assertEquals(error0, error1);
 
-        TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Function", error0::asFunction);
-        TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Event", error0::asEvent);
+        assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Function", error0::asFunction);
+        assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Event", error0::asEvent);
     }
 
     private static void testError(ContractError error, String json, JsonObject object) {
@@ -615,10 +616,10 @@ public class ABIJSONTest {
         assertEquals(1, errList.size());
         assertTrue(errList.stream().anyMatch(ABIObject::isContractError));
 
-        TestUtils.assertThrown(UnsupportedOperationException.class, () -> ABIJSON.FUNCTIONS.add(TypeEnum.EVENT));
-        TestUtils.assertThrown(UnsupportedOperationException.class, () -> ABIJSON.EVENTS.add(TypeEnum.CONSTRUCTOR));
-        TestUtils.assertThrown(UnsupportedOperationException.class, () -> ABIJSON.ERRORS.add(TypeEnum.EVENT));
-        TestUtils.assertThrown(UnsupportedOperationException.class, () -> ABIJSON.ALL.remove(TypeEnum.EVENT));
+        assertThrown(UnsupportedOperationException.class, () -> ABIJSON.FUNCTIONS.add(TypeEnum.EVENT));
+        assertThrown(UnsupportedOperationException.class, () -> ABIJSON.EVENTS.add(TypeEnum.CONSTRUCTOR));
+        assertThrown(UnsupportedOperationException.class, () -> ABIJSON.ERRORS.add(TypeEnum.EVENT));
+        assertThrown(UnsupportedOperationException.class, () -> ABIJSON.ALL.remove(TypeEnum.EVENT));
     }
 
     @Test
@@ -707,7 +708,7 @@ public class ABIJSONTest {
     }
 
     @Test
-    public void testInternalType() {
+    public void testInternalType() throws Throwable {
         String eventStr =
                 "{\n" +
                 "  \"type\": \"event\",\n" +
@@ -739,6 +740,9 @@ public class ABIJSONTest {
 
         TupleType nonIndexed = e.getNonIndexedParams();
         assertEquals("struct Thing[]", nonIndexed.getElementInternalType(0));
+
+        assertThrown(ArrayIndexOutOfBoundsException.class, () -> nonIndexed.getElementInternalType(-1));
+        assertThrown(ArrayIndexOutOfBoundsException.class, () -> nonIndexed.getElementInternalType(1));
 
         System.out.println(e);
 

--- a/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
@@ -264,22 +264,22 @@ public class ABIJSONTest {
         }
 
         for (String originalJson : jsons) {
-            ABIObject orig = ABIObject.fromJsonObject(JsonUtils.parseObject(originalJson));
+            ABIObject orig = ABIObject.fromJsonObject(JsonUtils.parseObject(originalJson), ArrayType.NO_FLAGS);
             String newJson = orig.toJson(false);
             assertNotEquals(originalJson, newJson);
 
-            ABIObject reconstructed = ABIObject.fromJsonObject(JsonUtils.parseObject(newJson));
+            ABIObject reconstructed = ABIObject.fromJsonObject(JsonUtils.parseObject(newJson), ArrayType.NO_FLAGS);
 
             assertEquals(orig, reconstructed);
             assertEquals(originalJson, reconstructed.toString());
-            assertEquals(orig, ABIObject.fromJson(newJson));
+            assertEquals(orig, ABIObject.fromJson(newJson, ArrayType.NO_FLAGS));
         }
     }
 
     @Test
     public void testParseFunctionA() throws Throwable {
         final JsonObject object = JsonUtils.parseObject(FUNCTION_A_JSON);
-        final Function f = Function.fromJsonObject(object);
+        final Function f = Function.fromJsonObject(object, ArrayType.NO_FLAGS);
         assertEquals(FUNCTION_A_JSON, f.toJson(true));
         final TupleType in = f.getInputs();
         final TupleType out = f.getOutputs();
@@ -308,9 +308,9 @@ public class ABIJSONTest {
         printTupleType(in);
         printTupleType(out);
 
-        Function f2 = ABIObject.fromJson(FUNCTION_A_JSON);
+        Function f2 = ABIObject.fromJson(FUNCTION_A_JSON, ArrayType.NO_FLAGS);
         assertEquals(f, f2);
-        assertEquals(f, ABIObject.fromJsonObject(object));
+        assertEquals(f, ABIObject.fromJsonObject(object, ArrayType.NO_FLAGS));
 
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", f2::asContractError);
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Event", f2::asEvent);
@@ -338,7 +338,7 @@ public class ABIJSONTest {
     public void testParseFunction2() throws Throwable {
         final JsonObject function = new JsonObject();
 
-        TestUtils.CustomRunnable parse = () -> Function.fromJsonObject(function);
+        TestUtils.CustomRunnable parse = () -> Function.fromJsonObject(function, ArrayType.NO_FLAGS);
 
         TestUtils.assertThrown(IllegalArgumentException.class, "type is \"function\"; functions of this type must define name", parse);
 
@@ -395,9 +395,9 @@ public class ABIJSONTest {
         String json = jsonObject.toString();
         assertEquals(expectedA, Event.fromJson(json));
 
-        Event e = ABIObject.fromJson(json);
+        Event e = ABIObject.fromJson(json, ArrayType.NO_FLAGS);
         assertEquals(expectedA, e);
-        assertEquals(e, ABIObject.fromJsonObject(jsonObject));
+        assertEquals(e, ABIObject.fromJsonObject(jsonObject, ArrayType.NO_FLAGS));
 
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.ContractError", e::asContractError);
         TestUtils.assertThrown(ClassCastException.class, "com.esaulpaugh.headlong.abi.Function", e::asFunction);
@@ -541,7 +541,7 @@ public class ABIJSONTest {
         JsonObject object = JsonUtils.parseObject(ERROR_JSON);
 
         ContractError error0 = ABIJSON.parseErrors(ERROR_JSON_ARRAY).get(0);
-        ContractError error1 = ABIObject.fromJsonObject(object);
+        ContractError error1 = ABIObject.fromJsonObject(object, ArrayType.NO_FLAGS);
 
         testError(error0, ERROR_JSON, object);
         testError(error1, ERROR_JSON, object);
@@ -563,8 +563,8 @@ public class ABIJSONTest {
 
         testEqualNotSame(error, ContractError.fromJson(json));
         testEqualNotSame(error, ContractError.fromJsonObject(object));
-        testEqualNotSame(error, ABIObject.fromJson(json));
-        testEqualNotSame(error, ABIObject.fromJsonObject(object));
+        testEqualNotSame(error, ABIObject.fromJson(json, ArrayType.NO_FLAGS));
+        testEqualNotSame(error, ABIObject.fromJsonObject(object, ArrayType.NO_FLAGS));
 
         assertFalse(error.isFunction());
         assertFalse(error.isEvent());

--- a/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/ABIJSONTest.java
@@ -279,7 +279,7 @@ public class ABIJSONTest {
     @Test
     public void testParseFunctionA() throws Throwable {
         final JsonObject object = JsonUtils.parseObject(FUNCTION_A_JSON);
-        final Function f = Function.fromJsonObject(object, ABIType.FLAGS_NONE);
+        final Function f = Function.fromJsonObject(ABIType.FLAGS_NONE, object);
         assertEquals(FUNCTION_A_JSON, f.toJson(true));
         final TupleType in = f.getInputs();
         final TupleType out = f.getOutputs();
@@ -338,7 +338,7 @@ public class ABIJSONTest {
     public void testParseFunction2() throws Throwable {
         final JsonObject function = new JsonObject();
 
-        TestUtils.CustomRunnable parse = () -> Function.fromJsonObject(function, ABIType.FLAGS_NONE);
+        TestUtils.CustomRunnable parse = () -> Function.fromJsonObject(ABIType.FLAGS_NONE, function);
 
         TestUtils.assertThrown(IllegalArgumentException.class, "type is \"function\"; functions of this type must define name", parse);
 

--- a/src/test/java/com/esaulpaugh/headlong/abi/BasicABICasesTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/BasicABICasesTest.java
@@ -105,18 +105,19 @@ public class BasicABICasesTest {
     private static TupleType wrap(ABIType<?>... elements) {
         final StringBuilder canonicalBuilder = new StringBuilder("(");
         boolean dynamic = false;
+        int flags = -1;
         for (ABIType<?> e : elements) {
             canonicalBuilder.append(e.canonicalType).append(',');
             dynamic |= e.dynamic;
+            if (e.flags != flags && e.flags != ABIType.FLAGS_UNSET) {
+                if (flags == -1) {
+                    flags = e.flags;
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            }
         }
-        return new TupleType(completeTupleTypeString(canonicalBuilder), dynamic, elements, null, null);
-    }
-
-    private static String completeTupleTypeString(StringBuilder sb) {
-        final int len = sb.length();
-        return len != 1
-                ? sb.deleteCharAt(len - 1).append(')').toString() // replace trailing comma
-                : "()";
+        return new TupleType(TestUtils.completeTupleTypeString(canonicalBuilder), dynamic, elements, null, null, flags);
     }
 
     @Test

--- a/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
@@ -926,6 +926,10 @@ public class DecodeTest {
         final ByteBuffer bb = f.encodeCall(args);
         assertArrayEquals(Strings.decode("627dd56a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020964000000000000000000000000000000000000000000000000000000000000"), bb.array());
 
+//        assertThrown(UnsupportedOperationException.class, () -> f.getInputs().encode(args));
+//        assertThrown(UnsupportedOperationException.class, () -> f.getInputs().encode(args, ByteBuffer.allocate(128)));
+//        assertThrown(UnsupportedOperationException.class, () -> f.encodeCall(args));
+//        assertThrown(UnsupportedOperationException.class, () -> f.encodeCallWithArgs((Object)new byte[0]));
 
         final String unpaddedHex = "627dd56a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020964";
         final byte[] unpadded = Strings.decode(unpaddedHex);

--- a/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
@@ -916,8 +916,11 @@ public class DecodeTest {
     @Test
     public void testLegacyDecode() throws Throwable {
         final Function f = Function.fromJson(FN_JSON, ABIType.FLAG_LEGACY_DECODE);
-
+        final Function f2 = (Function) ABIJSON.parseElements("[" + FN_JSON + "]", ABIJSON.ALL, ABIType.FLAG_LEGACY_DECODE).get(0);
         checkLegacyFlags(f.getInputs());
+        checkLegacyFlags(f2.getInputs());
+
+        assertEquals(f, f2);
 
         final Tuple args = Tuple.singleton(new byte[] { 9, 100 });
         final ByteBuffer bb = f.encodeCall(args);

--- a/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
@@ -916,7 +916,7 @@ public class DecodeTest {
     @Test
     public void testLegacyDecode() throws Throwable {
         final Function f = Function.fromJson(FN_JSON, ABIType.FLAG_LEGACY_DECODE);
-        final Function f2 = (Function) ABIJSON.parseElements("[" + FN_JSON + "]", ABIJSON.ALL, ABIType.FLAG_LEGACY_DECODE).get(0);
+        final Function f2 = (Function) ABIJSON.parseElements(ABIType.FLAG_LEGACY_DECODE, "[" + FN_JSON + "]", ABIJSON.ALL).get(0);
         checkLegacyFlags(f.getInputs());
         checkLegacyFlags(f2.getInputs());
 

--- a/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
@@ -915,7 +915,7 @@ public class DecodeTest {
 
     @Test
     public void testLegacyDecode() throws Throwable {
-        final Function f = Function.fromJson(FN_JSON, ABIType.FLAG_LEGACY_DECODE);
+        final Function f = Function.fromJson(ABIType.FLAG_LEGACY_DECODE, FN_JSON);
         final Function f2 = (Function) ABIJSON.parseElements(ABIType.FLAG_LEGACY_DECODE, "[" + FN_JSON + "]", ABIJSON.ALL).get(0);
         checkLegacyFlags(f.getInputs());
         checkLegacyFlags(f2.getInputs());

--- a/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
@@ -898,4 +898,59 @@ public class DecodeTest {
                 )
         );
     }
+
+    @Test
+    public void testLegacyDecode() {
+        final String hex = "128acb08000000000000000000000000da3a20aad0c34fa742bd9813d45bbf67c787ae0b0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffdb9328a9ba5635a80846cdf000000000000000000000000fffd8963efd1fc6a506488495d951d5263988d2500000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000016200163301ee63fb29f863f2333bd4466acb46cd8323e620cd9dab5e666de980cecdc180cb31f296733e258700000246cd75645a9ca57f7b9320004bb0641100000000000000beebe34d7e60da18da3a20aad0c34fa742bd9813d45bbf67c787ae0b0000000000000000c34333f9af9c04005800132f152689a72b0a484b49a37fc85a862006f4138f1b000000000000000a31acd25057ef0000000000e17c19c8ee8c58656d0035189628a3e880960bd07f47bdfeb91de21a4c9b431a00000000000000000dbaac192510fe00940106450dee7fd2fb8e39061434babcfc05599a6fb8202a9d2ba41aba912316d16742f259412b681898db00000007f5368cf7b9ce855960c0004bb0641100000000000000475b46c4aab2f8109f5b65fa97d1fd596e9d111d483f90f69cd8102a000000000004ac23d1c23b55042949007118742f53651043cbab06602299064d59deb60a745300000000000000004e3fe9b51a631e";
+        final int len = hex.length();
+        final int roundedDown = len / 32 * 32;
+        System.out.println(len + " === " + roundedDown + " + " + (len - roundedDown));
+        final Function f = Function.fromJson("{\n" +
+                "  \"inputs\": [\n" +
+                "    {\n" +
+                "      \"internalType\": \"address\",\n" +
+                "      \"name\": \"recipient\",\n" +
+                "      \"type\": \"address\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"internalType\": \"bool\",\n" +
+                "      \"name\": \"zeroForOne\",\n" +
+                "      \"type\": \"bool\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"internalType\": \"int256\",\n" +
+                "      \"name\": \"amountSpecified\",\n" +
+                "      \"type\": \"int256\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"internalType\": \"uint160\",\n" +
+                "      \"name\": \"sqrtPriceLimitX96\",\n" +
+                "      \"type\": \"uint160\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"internalType\": \"bytes\",\n" +
+                "      \"name\": \"data\",\n" +
+                "      \"type\": \"bytes\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"name\": \"swap\",\n" +
+                "  \"outputs\": [\n" +
+                "    {\n" +
+                "      \"internalType\": \"int256\",\n" +
+                "      \"name\": \"amount0\",\n" +
+                "      \"type\": \"int256\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"internalType\": \"int256\",\n" +
+                "      \"name\": \"amount1\",\n" +
+                "      \"type\": \"int256\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"stateMutability\": \"nonpayable\",\n" +
+                "  \"type\": \"function\"\n" +
+                "}", ArrayType.FLAG_LEGACY);
+
+        Tuple result = f.decodeCall(Strings.decode(hex));
+        System.out.println(result);
+    }
 }

--- a/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
@@ -915,28 +915,30 @@ public class DecodeTest {
 
     @Test
     public void testLegacyDecode() throws Throwable {
-        final Function f = Function.fromJson(FN_JSON, ABIType.FLAG_LEGACY_ARRAY);
+        final Function f = Function.fromJson(FN_JSON, ABIType.FLAG_LEGACY_DECODE);
 
         checkLegacyFlags(f.getInputs());
 
         final Tuple args = Tuple.singleton(new byte[] { 9, 100 });
+        final ByteBuffer bb = f.encodeCall(args);
+        assertArrayEquals(Strings.decode("627dd56a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020964000000000000000000000000000000000000000000000000000000000000"), bb.array());
 
 
-        final String hex = "627dd56a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020964";
-        final byte[] hexBytes = Strings.decode(hex);
-        assertEquals(args, f.getInputs().decode(Arrays.copyOfRange(hexBytes, Function.SELECTOR_LEN, hexBytes.length)));
-        assertEquals(args, f.decodeCall(hexBytes));
+        final String unpaddedHex = "627dd56a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020964";
+        final byte[] unpadded = Strings.decode(unpaddedHex);
+        assertEquals(args, f.getInputs().decode(Arrays.copyOfRange(unpadded, Function.SELECTOR_LEN, unpadded.length)));
+        assertEquals(args, f.decodeCall(unpadded));
     }
 
     private void checkLegacyFlags(ABIType<?> t) throws Throwable {
         if (t instanceof TupleType) {
-            assertEquals(ABIType.FLAG_LEGACY_ARRAY, t.flags);
+            assertEquals(ABIType.FLAG_LEGACY_DECODE, t.flags);
             for (ABIType<?> e : (TupleType) t) {
                 checkLegacyFlags(e);
             }
         } else if (t instanceof ArrayType) {
-            assertTrue(((ArrayType<?, ?>) t).legacy);
-            assertEquals(ABIType.FLAG_LEGACY_ARRAY, t.flags);
+            assertTrue(((ArrayType<?, ?>) t).legacyDecode);
+            assertEquals(ABIType.FLAG_LEGACY_DECODE, t.flags);
             checkLegacyFlags(((ArrayType<?, ?>) t).getElementType());
         } else {
             assertEquals(ABIType.FLAGS_UNSET, t.flags);

--- a/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
@@ -954,35 +954,43 @@ public class DecodeTest {
     }
 
     @Test
-    public void testString() {
+    public void testLegacyString() {
         final String json = "{\n" +
-                "\"constant\": false,\n" +
-                "\"inputs\": [\n" +
-                "  {\n" +
-                "    \"internalType\": \"string\",\n" +
-                "    \"name\": \"name\",\n" +
-                "    \"type\": \"string\"\n" +
-                "  }\n" +
-                "],\n" +
-                "\"name\": \"registerWithConfig\",\n" +
-                "\"outputs\": [],\n" +
-                "\"payable\": true,\n" +
-                "\"stateMutability\": \"payable\",\n" +
-                "\"type\": \"function\"\n" +
+                "  \"type\": \"function\",\n" +
+                "  \"name\": \"registerWithConfig\",\n" +
+                "  \"inputs\": [\n" +
+                "    {\n" +
+                "      \"internalType\": \"string\",\n" +
+                "      \"name\": \"name\",\n" +
+                "      \"type\": \"string\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"outputs\": [],\n" +
+                "  \"stateMutability\": \"payable\"\n" +
                 "}";
 
-        final Function f = Function.fromJson(ABIType.FLAG_LEGACY_DECODE, json);
-        final Function f2 = Function.fromJson(ABIType.FLAGS_NONE, json);
+        final Function leg = Function.fromJson(ABIType.FLAG_LEGACY_DECODE, json);
+        final Function norm = Function.fromJson(ABIType.FLAGS_NONE, json);
 
-        System.out.println(Strings.encode(f2.encodeCall(Tuple.singleton("jason566"))));
-
-        final String hex = "d7f3de49000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000085a67336f6e303136000000000000000000000000000000000000000000000000";
+        final String hex =  "d7f3de49" +
+                            "0000000000000000000000000000000000000000000000000000000000000020" +
+                            "0000000000000000000000000000000000000000000000000000000000000008" +
+                            "5a67336f6e303136000000000000000000000000000000000000000000000000";
         final byte[] bytes = Strings.decode(hex);
 
-        final Tuple dec0 = f.decodeCall(ByteBuffer.wrap(bytes));
-        final Tuple dec1 = f2.decodeCall(ByteBuffer.wrap(bytes));
+        final ByteBuffer input = ByteBuffer.wrap(bytes);
 
-        assertEquals("Zg3on016", dec0.get(0));
-        assertEquals("Zg3on016", dec1.get(0));
+        final String expected = "Zg3on016";
+
+        input.mark();
+        final Tuple dec0 = leg.decodeCall(input);
+        assertEquals(UnitType.UNIT_LENGTH_BYTES - expected.length(), input.remaining());
+        assertEquals(expected, dec0.get(0));
+
+        input.reset();
+        final Tuple dec1 = norm.decodeCall(input);
+        assertEquals(input.capacity(), input.position());
+        assertEquals(0, input.remaining());
+        assertEquals(expected, dec1.get(0));
     }
 }

--- a/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
@@ -952,4 +952,37 @@ public class DecodeTest {
             assertThrown(UnsupportedOperationException.class, t::getFlags);
         }
     }
+
+    @Test
+    public void testString() {
+        final String json = "{\n" +
+                "\"constant\": false,\n" +
+                "\"inputs\": [\n" +
+                "  {\n" +
+                "    \"internalType\": \"string\",\n" +
+                "    \"name\": \"name\",\n" +
+                "    \"type\": \"string\"\n" +
+                "  }\n" +
+                "],\n" +
+                "\"name\": \"registerWithConfig\",\n" +
+                "\"outputs\": [],\n" +
+                "\"payable\": true,\n" +
+                "\"stateMutability\": \"payable\",\n" +
+                "\"type\": \"function\"\n" +
+                "}";
+
+        final Function f = Function.fromJson(ABIType.FLAG_LEGACY_DECODE, json);
+        final Function f2 = Function.fromJson(ABIType.FLAGS_NONE, json);
+
+        System.out.println(Strings.encode(f2.encodeCall(Tuple.singleton("jason566"))));
+
+        final String hex = "d7f3de49000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000085a67336f6e303136000000000000000000000000000000000000000000000000";
+        final byte[] bytes = Strings.decode(hex);
+
+        final Tuple dec0 = f.decodeCall(ByteBuffer.wrap(bytes));
+        final Tuple dec1 = f2.decodeCall(ByteBuffer.wrap(bytes));
+
+        assertEquals("Zg3on016", dec0.get(0));
+        assertEquals("Zg3on016", dec1.get(0));
+    }
 }

--- a/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/DecodeTest.java
@@ -948,7 +948,7 @@ public class DecodeTest {
                 "  ],\n" +
                 "  \"stateMutability\": \"nonpayable\",\n" +
                 "  \"type\": \"function\"\n" +
-                "}", ArrayType.FLAG_LEGACY);
+                "}", ABIType.FLAG_LEGACY_ARRAY);
 
         Tuple result = f.decodeCall(Strings.decode(hex));
         System.out.println(result);

--- a/src/test/java/com/esaulpaugh/headlong/abi/EqualsTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/EqualsTest.java
@@ -30,6 +30,7 @@ import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -189,5 +190,40 @@ public class EqualsTest {
         BigInteger[] decoded = dec.get(0);
 
         assertArrayEquals(unsigneds, decoded);
+    }
+
+    @Test
+    public void testFlagsEquals() {
+        final String typeString = "(bytes[4][],bytes30[],string[])";
+        final TupleType tt_a = TupleType.parse(typeString);
+        final TupleType tt_b = TupleType.parse(ABIType.FLAGS_NONE, typeString);
+        final TupleType tt_c = TupleType.parse(ABIType.FLAG_LEGACY_DECODE, typeString);
+
+        assertEquals(tt_a, tt_b);
+        assertNotEquals(tt_a, tt_c);
+
+        assertEquals(TypeFactory.create(typeString), TypeFactory.create(ABIType.FLAGS_NONE, typeString));
+        assertNotEquals(TypeFactory.create(typeString), TypeFactory.create(ABIType.FLAG_LEGACY_DECODE, typeString));
+
+        assertEquals(TypeFactory.create(typeString), TypeFactory.create(ABIType.FLAGS_NONE, typeString));
+        assertNotEquals(TypeFactory.create(typeString), TypeFactory.create(ABIType.FLAG_LEGACY_DECODE, typeString));
+
+        assertEquals(
+                Function.parse(typeString),
+                Function.parse(ABIType.FLAGS_NONE, typeString, "()")
+        );
+        assertNotEquals(
+                Function.parse(typeString),
+                Function.parse(ABIType.FLAG_LEGACY_DECODE, typeString, "()")
+        );
+
+        assertEquals(
+                new Event("lo", false, tt_a, false, false, false),
+                Event.create("lo", tt_b, false, false, false)
+        );
+        assertNotEquals(
+                new Event("lo", false, tt_a, false, false, false),
+                Event.create("lo", tt_c, false, false, false)
+        );
     }
 }

--- a/src/test/java/com/esaulpaugh/headlong/abi/MonteCarloTestCase.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/MonteCarloTestCase.java
@@ -150,6 +150,10 @@ public class MonteCarloTestCase {
         return function.getName() + rawInputsStr;
     }
 
+    long getSeed() {
+        return seed;
+    }
+
     private static void testDeepCopy(Tuple values) {
         final Tuple copy = values.deepCopy();
         assertNotSame(values, copy);

--- a/src/test/java/com/esaulpaugh/headlong/abi/TupleTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/TupleTest.java
@@ -333,7 +333,7 @@ public class TupleTest {
         for (ABIType<?> e : elements) {
             canonicalBuilder.append(e.canonicalType).append(',');
             dynamic |= e.dynamic;
-            if (e.flags != flags) {
+            if (e.flags != flags && e.flags != ABIType.FLAGS_UNSET) {
                 if (flags == -1) {
                     flags = e.flags;
                 } else {

--- a/src/test/java/com/esaulpaugh/headlong/abi/TupleTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/TupleTest.java
@@ -290,10 +290,10 @@ public class TupleTest {
                 () -> TypeFactory.createTupleTypeWithNames("(bool,string)", new String[4]));
 
         TupleType tt = TypeFactory.createTupleTypeWithNames("(bool,string)", "a", "b");
-        assertThrown(IllegalArgumentException.class, "index out of bounds: -1", () -> tt.getElementName(-1));
+        assertThrown(ArrayIndexOutOfBoundsException.class, () -> tt.getElementName(-1));
         assertEquals("a", tt.getElementName(0));
         assertEquals("b", tt.getElementName(1));
-        assertThrown(IllegalArgumentException.class, "index out of bounds: 2", () -> tt.getElementName(2));
+        assertThrown(ArrayIndexOutOfBoundsException.class, () -> tt.getElementName(2));
     }
 
     private static void testNameOverwrite(String typeStr, String aName, String cName) {

--- a/src/test/java/com/esaulpaugh/headlong/abi/TupleTest.java
+++ b/src/test/java/com/esaulpaugh/headlong/abi/TupleTest.java
@@ -329,18 +329,19 @@ public class TupleTest {
     private static TupleType wrap(String[] elementNames, ABIType<?>... elements) {
         final StringBuilder canonicalBuilder = new StringBuilder("(");
         boolean dynamic = false;
+        int flags = -1;
         for (ABIType<?> e : elements) {
             canonicalBuilder.append(e.canonicalType).append(',');
             dynamic |= e.dynamic;
+            if (e.flags != flags) {
+                if (flags == -1) {
+                    flags = e.flags;
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            }
         }
-        return new TupleType(completeTupleTypeString(canonicalBuilder), dynamic, elements, elementNames, null);
-    }
-
-    private static String completeTupleTypeString(StringBuilder sb) {
-        final int len = sb.length();
-        return len != 1
-                ? sb.deleteCharAt(len - 1).append(')').toString() // replace trailing comma
-                : "()";
+        return new TupleType(TestUtils.completeTupleTypeString(canonicalBuilder), dynamic, elements, elementNames, null, flags);
     }
 
     @Test


### PR DESCRIPTION
This is intended to assist with decoding legacy Solidity ABI encodings, specifically as in Solidity v0.4.X and earlier (i.e. before Solidity version 0.5).

Setting this new experimental flag (`ABIType.FLAG_LEGACY_DECODE`, value 1) during `ABIType` creation (e.g. when creating a `Function` or `Event`) enables an incompatible decoding mode which is local to the object created and the internally-created objects on which it depends (e.g. the object returned by `Function#getInputs()`. This mode assumes that all byte arrays (including strings) encountered will have no trailing padding bytes. Other behavior such as encoding is not affected. This means that any `ABIType`, `Function`, or `Event` which enables this flag cannot be used to decode specification-compliant encodings. This includes encodings made by these same objects, as their encoding output is still compliant.

If the legacy array flag is not set (for example if you specify `ABIType.FLAGS_NONE`, value 0) then the `ABIType`, `Function`, or `Event` should expect that all byte arrays have the appropriate padding according to the current ABI specification. In other words, if no flags are set then everything should behave exactly as before in all respects.

Testing and feedback are appreciated and will help ensure correctness and a timely release.