### PR TITLE
use gson v2.12.0, parse json strictly

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -30,4 +30,4 @@ jobs:
           java -version
           chmod +x ./gradlew
           ./gradlew build --no-daemon
-          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.10.1/b3add478d4382b78ea20b1671390a858002feb6c" clean all build-jar
+          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.11.0/527175ca6d81050b53bdd4c457a6d6e017626b0e" clean all build-jar

--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -30,4 +30,4 @@ jobs:
           java -version
           chmod +x ./gradlew
           ./gradlew build --no-daemon
-          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.11.0/527175ca6d81050b53bdd4c457a6d6e017626b0e" clean all build-jar
+          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.12.0/10596b68aaca6230f7c40bfd9298b21ff4b84103" clean all build-jar

--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: ${{ matrix.distribution }}
-          java-version: '8.0.432'
+          java-version: '8.0.442'
           java-package: jdk
           cache: 'gradle'
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-            gradle-version: 5.0
+            gradle-version: 5.6.4
 
       - name: Run gradle and ant builds
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-            gradle-version: 4.10.3
+            gradle-version: 4.6
 
       - name: Run gradle and ant builds
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,4 +34,4 @@ jobs:
           java -version
           gradle -version
           gradle build --no-daemon
-          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.10.1/b3add478d4382b78ea20b1671390a858002feb6c" clean all build-jar
+          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.11.0/527175ca6d81050b53bdd4c457a6d6e017626b0e" clean all build-jar

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,4 +34,4 @@ jobs:
           java -version
           gradle -version
           gradle build --no-daemon
-          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.11.0/527175ca6d81050b53bdd4c457a6d6e017626b0e" clean all build-jar
+          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.12.0/10596b68aaca6230f7c40bfd9298b21ff4b84103" clean all build-jar

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-            gradle-version: 4.6
+            gradle-version: 5.0
 
       - name: Run gradle and ant builds
         run: |

--- a/.github/workflows/x86.yml
+++ b/.github/workflows/x86.yml
@@ -31,4 +31,4 @@ jobs:
           java -version
           chmod +x ./gradlew
           ./gradlew build --no-daemon
-          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.11.0/527175ca6d81050b53bdd4c457a6d6e017626b0e" clean all build-jar
+          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.12.0/10596b68aaca6230f7c40bfd9298b21ff4b84103" clean all build-jar

--- a/.github/workflows/x86.yml
+++ b/.github/workflows/x86.yml
@@ -31,4 +31,4 @@ jobs:
           java -version
           chmod +x ./gradlew
           ./gradlew build --no-daemon
-          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.10.1/b3add478d4382b78ea20b1671390a858002feb6c" clean all build-jar
+          ant -noinput -buildfile build.xml -Drepository="/.gradle/caches/modules-2/files-2.1" -Dgson_path="/com.google.code.gson/gson/2.11.0/527175ca6d81050b53bdd4c457a6d6e017626b0e" clean all build-jar

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Also includes optimized implementations of:
 * Keccak
 * hexadecimal
 
-headlong depends on gson v2.11.0 for the abi package. Test suite should take less than one minute to run. Test packages require junit. Jar size is ~128 KiB. Java 8+.
+headlong depends on gson v2.1 or greater at runtime and v2.11.0 or greater at compile time. Test suite should take less than one minute to run. Test packages require junit. Jar size is ~128 KiB. Java 8+.
 
 See the wiki for more, such as packed encoding (and decoding) and RLP Object Notation: https://github.com/esaulpaugh/headlong/wiki
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Also includes optimized implementations of:
 
 headlong depends on gson v2.1 or greater at runtime and v2.11.0 or greater at compile time. Test suite should take less than one minute to run. Test packages require junit. Jar size is ~128 KiB. Java 8+.
 
+For best JSON parsing performance, make sure objects are compact and that the "type" field is positioned first. See ABIJSON.tryParseStreaming.
+
 See the wiki for more, such as packed encoding (and decoding) and RLP Object Notation: https://github.com/esaulpaugh/headlong/wiki
 
 Licensed under Apache 2.0 terms

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Also includes optimized implementations of:
 
 headlong depends on gson v2.1 or greater at runtime and v2.11.0 or greater at compile time. Test suite should take less than one minute to run. Test packages require junit. Jar size is ~128 KiB. Java 8+.
 
-For best JSON parsing performance, make sure objects are compact and that the "type" field is positioned first. See ABIJSON.tryParseStreaming.
+For best JSON parsing performance, make sure objects are compact and that the "type" field is positioned first. See ABIJSON.tryParseStreaming. This can be done via the method `Function#toJson(boolean)` while giving `false` as the argument (no pretty print).
 
 See the wiki for more, such as packed encoding (and decoding) and RLP Object Notation: https://github.com/esaulpaugh/headlong/wiki
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Also includes optimized implementations of:
 * Keccak
 * hexadecimal
 
-headlong depends on gson v2.10.1 for the abi package. Test suite should take less than one minute to run. Test packages require junit. Jar size is ~128 KiB. Java 8+.
+headlong depends on gson v2.11.0 for the abi package. Test suite should take less than one minute to run. Test packages require junit. Jar size is ~128 KiB. Java 8+.
 
 See the wiki for more, such as packed encoding (and decoding) and RLP Object Notation: https://github.com/esaulpaugh/headlong/wiki
 

--- a/build.gradle
+++ b/build.gradle
@@ -87,16 +87,24 @@ repositories {
     mavenCentral()
 }
 
+final String gsonVersion = "2.12.0"
 final String junitVersion = "5.11.4"
 final String jmhVersion = "1.37"
 final String bcVersion = "1.80"
 
 dependencies {
-    implementation('com.google.code.gson:gson:2.12.0') {
+    implementation("com.google.code.gson:gson:" + gsonVersion) {
         version {
-            strictly '[2.1,2.12.0]'
+            prefer(gsonVersion)
         }
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        exclude(group: "com.google.errorprone", module: "error_prone_annotations")
+    }
+    constraints {
+        implementation("com.google.code.gson:gson") {
+            version {
+                require("[2.1,)")
+            }
+        }
     }
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:" + junitVersion)

--- a/build.gradle
+++ b/build.gradle
@@ -92,9 +92,9 @@ final String jmhVersion = "1.37"
 final String bcVersion = "1.80"
 
 dependencies {
-    implementation('com.google.code.gson:gson:2.11.0') {
+    implementation('com.google.code.gson:gson:2.12.0') {
         version {
-            strictly '[2.1,2.11.0]'
+            strictly '[2.1,2.12.0]'
         }
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,10 @@ final String jmhVersion = "1.37"
 final String bcVersion = "1.80"
 
 dependencies {
-    implementation("com.google.code.gson:gson:2.11.0") {
+    implementation('com.google.code.gson:gson:2.11.0') {
+        version {
+            strictly '[2.1,2.11.0]'
+        }
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,9 @@ final String jmhVersion = "1.37"
 final String bcVersion = "1.80"
 
 dependencies {
-    implementation("com.google.code.gson:gson:2.10.1")
+    implementation("com.google.code.gson:gson:2.11.0") {
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+    }
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:" + junitVersion)
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:" + junitVersion)

--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,7 @@ version = "12.3.4-SNAPSHOT"
 final String versionStr = getProject().getGradle().getGradleVersion()
 final int gradleMajorVersion = Integer.parseUnsignedInt(versionStr.substring(0, versionStr.indexOf('.')))
 
-if (gradleMajorVersion >= 5) {
-    java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-} else {
+java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
@@ -92,27 +87,26 @@ repositories {
     mavenCentral()
 }
 
+final String gsonVersion = "2.12.0"
 final String junitVersion = "5.11.4"
 final String jmhVersion = "1.37"
 final String bcVersion = "1.80"
 
-final String compileRange = "[2.11.0, 2.12.0]"
+final String requires = "[2.1, " + gsonVersion + "]"
+final String runtimeRange = "[2.1,)"
 
 dependencies {
-    implementation("com.google.code.gson:gson") {
-        if (gradleMajorVersion >= 5) {
-            version {
-                require(compileRange)
-            }
-        } else {
-            version(compileRange)
+    implementation("com.google.code.gson:gson:" + gsonVersion) {
+        version {
+            require(requires) // published in "dependencies"
         }
-
         exclude(group: "com.google.errorprone", module: "error_prone_annotations")
     }
     constraints {
-        implementation("com.google.code.gson:gson:2.12.0") {
-            version("[2.1,)") // gets published to consumers
+        implementation("com.google.code.gson:gson:") {
+            version {
+                require(runtimeRange) // published in "dependencyConstraints" / "<dependencyManagement>"
+            }
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,12 @@ version = "12.3.4-SNAPSHOT"
 final String versionStr = getProject().getGradle().getGradleVersion()
 final int gradleMajorVersion = Integer.parseUnsignedInt(versionStr.substring(0, versionStr.indexOf('.')))
 
-java {
+if (gradleMajorVersion >= 5) {
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+} else {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
@@ -87,17 +92,28 @@ repositories {
     mavenCentral()
 }
 
-final String gsonVersion = "2.12.0"
 final String junitVersion = "5.11.4"
 final String jmhVersion = "1.37"
 final String bcVersion = "1.80"
 
+final String compileRange = "[2.11.0, 2.12.0]"
+
 dependencies {
-    implementation("com.google.code.gson:gson:" + gsonVersion) {
-        version {
-            strictly(gsonVersion)
+    implementation("com.google.code.gson:gson") {
+        if (gradleMajorVersion >= 5) {
+            version {
+                require(compileRange)
+            }
+        } else {
+            version(compileRange)
         }
+
         exclude(group: "com.google.errorprone", module: "error_prone_annotations")
+    }
+    constraints {
+        implementation("com.google.code.gson:gson:2.12.0") {
+            version("[2.1,)") // gets published to consumers
+        }
     }
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:" + junitVersion)

--- a/build.gradle
+++ b/build.gradle
@@ -95,16 +95,9 @@ final String bcVersion = "1.80"
 dependencies {
     implementation("com.google.code.gson:gson:" + gsonVersion) {
         version {
-            prefer(gsonVersion)
+            strictly(gsonVersion)
         }
         exclude(group: "com.google.errorprone", module: "error_prone_annotations")
-    }
-    constraints {
-        implementation("com.google.code.gson:gson") {
-            version {
-                require("[2.1,)")
-            }
-        }
     }
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:" + junitVersion)

--- a/build.gradle
+++ b/build.gradle
@@ -92,8 +92,8 @@ final String junitVersion = "5.11.4"
 final String jmhVersion = "1.37"
 final String bcVersion = "1.80"
 
-final String requires = "[2.1, " + gsonVersion + "]"
-final String runtimeRange = "[2.1,)"
+final String requires = "[2.1, " + gsonVersion + "]" // cap the require at the preferred version
+final String runtimeRange = "[2.1,)" // allow later versions at runtime
 
 dependencies {
     implementation("com.google.code.gson:gson:" + gsonVersion) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@
 //dependencies {
 //    implementation("com.google.code.gson:gson:$gsonVersion") {
 //        version {
-//            prefer(gsonVersion)
+//            strictly(gsonVersion)
 //        }
 //        exclude(group = "com.google.errorprone", module = "error_prone_annotations")
 //    }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,12 +75,23 @@
 //    mavenCentral()
 //}
 //
+//val gsonVersion = "2.12.0"
 //val junitVersion = "5.11.4"
 //val bcVersion = "1.80"
 //
 //dependencies {
-//    implementation("com.google.code.gson:gson:2.11.0") {
+//    implementation("com.google.code.gson:gson:$gsonVersion") {
+//        version {
+//            prefer(gsonVersion)
+//        }
 //        exclude(group = "com.google.errorprone", module = "error_prone_annotations")
+//    }
+//    constraints {
+//        implementation("com.google.code.gson:gson") {
+//            version {
+//                require("[2.1,)")
+//            }
+//        }
 //    }
 //
 //    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,9 @@
 //val bcVersion = "1.80"
 //
 //dependencies {
-//    implementation("com.google.code.gson:gson:2.10.1")
+//    implementation("com.google.code.gson:gson:2.11.0") {
+//        exclude(group = "com.google.errorprone", module = "error_prone_annotations")
+//    }
 //
 //    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
 //    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")

--- a/build.xml
+++ b/build.xml
@@ -53,8 +53,8 @@
 
   <!-- Project Libraries -->
   
-  <path id="lib.mvn:_com.google.code.gson:gson:2.10.1.classpath">
-    <pathelement location="${user.home}${repository}${gson_path}/gson-2.10.1.jar"/>
+  <path id="lib.mvn:_com.google.code.gson:gson:2.11.0.classpath">
+    <pathelement location="${user.home}${repository}${gson_path}/gson-2.11.0.jar"/>
   </path>
 
   <!-- Modules -->
@@ -129,22 +129,22 @@
   </path>
   
   <path id="headlong.main.module.production.classpath">
-    <path refid="lib.mvn:_com.google.code.gson:gson:2.10.1.classpath"/>
+    <path refid="lib.mvn:_com.google.code.gson:gson:2.11.0.classpath"/>
   </path>
   
   <path id="headlong.main.runtime.production.module.classpath">
     <pathelement location="${headlong.main.output.dir}"/>
-    <path refid="lib.mvn:_com.google.code.gson:gson:2.10.1.classpath"/>
+    <path refid="lib.mvn:_com.google.code.gson:gson:2.11.0.classpath"/>
   </path>
   
   <path id="headlong.main.module.classpath">
     <pathelement location="${headlong.main.output.dir}"/>
-    <path refid="lib.mvn:_com.google.code.gson:gson:2.10.1.classpath"/>
+    <path refid="lib.mvn:_com.google.code.gson:gson:2.11.0.classpath"/>
   </path>
   
   <path id="headlong.main.runtime.module.classpath">
     <pathelement location="${headlong.main.output.dir}"/>
-    <path refid="lib.mvn:_com.google.code.gson:gson:2.10.1.classpath"/>
+    <path refid="lib.mvn:_com.google.code.gson:gson:2.11.0.classpath"/>
   </path>
   
   

--- a/build.xml
+++ b/build.xml
@@ -53,8 +53,8 @@
 
   <!-- Project Libraries -->
   
-  <path id="lib.mvn:_com.google.code.gson:gson:2.11.0.classpath">
-    <pathelement location="${user.home}${repository}${gson_path}/gson-2.11.0.jar"/>
+  <path id="lib.mvn:_com.google.code.gson:gson:2.12.0.classpath">
+    <pathelement location="${user.home}${repository}${gson_path}/gson-2.12.0.jar"/>
   </path>
 
   <!-- Modules -->
@@ -129,22 +129,22 @@
   </path>
   
   <path id="headlong.main.module.production.classpath">
-    <path refid="lib.mvn:_com.google.code.gson:gson:2.11.0.classpath"/>
+    <path refid="lib.mvn:_com.google.code.gson:gson:2.12.0.classpath"/>
   </path>
   
   <path id="headlong.main.runtime.production.module.classpath">
     <pathelement location="${headlong.main.output.dir}"/>
-    <path refid="lib.mvn:_com.google.code.gson:gson:2.11.0.classpath"/>
+    <path refid="lib.mvn:_com.google.code.gson:gson:2.12.0.classpath"/>
   </path>
   
   <path id="headlong.main.module.classpath">
     <pathelement location="${headlong.main.output.dir}"/>
-    <path refid="lib.mvn:_com.google.code.gson:gson:2.11.0.classpath"/>
+    <path refid="lib.mvn:_com.google.code.gson:gson:2.12.0.classpath"/>
   </path>
   
   <path id="headlong.main.runtime.module.classpath">
     <pathelement location="${headlong.main.output.dir}"/>
-    <path refid="lib.mvn:_com.google.code.gson:gson:2.11.0.classpath"/>
+    <path refid="lib.mvn:_com.google.code.gson:gson:2.12.0.classpath"/>
   </path>
   
   

--- a/graal-config/reflect-config.json
+++ b/graal-config/reflect-config.json
@@ -1,5 +1,27 @@
 [
   {
+    "name": "com.google.gson.stream.JsonReader",
+    "methods": [
+      {
+        "name": "setStrictness",
+        "parameterTypes": ["com.google.gson.Strictness"]
+      }
+    ]
+  },
+  {
+    "name": "com.google.gson.Strictness",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": ["java.lang.String"]
+      },
+      {
+        "name": "valueOf",
+        "parameterTypes": [ "java.lang.Class" ,"java.lang.String"]
+      }
+    ]
+  },
+  {
     "name" : "byte[]",
     "unsafeAllocated" : true
   },

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -32,17 +32,17 @@
       </trusted-keys>
    </configuration>
     <components>
-        <component group="com.google.code.gson" name="gson-parent" version="2.11.0">
-            <artifact name="gson-parent-2.11.0.pom">
-                <sha256 value="8acb1f3b72a6f026916ac0735bad9aab0293d527edb7b365327def13a9367b7a" origin="repo.maven.apache.org/maven2/"/>
+        <component group="com.google.code.gson" name="gson-parent" version="2.12.0">
+            <artifact name="gson-parent-2.12.0.pom">
+                <sha256 value="b6dd0454a689944b4a66641c90792b59888ad24f43be69bcf6b165e2e29ce010" origin="repo.maven.apache.org/maven2/"/>
             </artifact>
         </component>
-        <component group="com.google.code.gson" name="gson" version="2.11.0">
-            <artifact name="gson-2.11.0.jar">
-                <sha256 value="57928d6e5a6edeb2abd3770a8f95ba44dce45f3b23b7a9dc2b309c581552a78b" origin="repo.maven.apache.org/maven2/"/>
+        <component group="com.google.code.gson" name="gson" version="2.12.0">
+            <artifact name="gson-2.12.0.jar">
+                <sha256 value="4d377f51c84bb5b4e5603bdee5fe7ffc9ab6b7aee4ee0e1f62c6fadd84c5fa05" origin="repo.maven.apache.org/maven2/"/>
             </artifact>
-            <artifact name="gson-2.11.0.pom">
-                <sha256 value="c0e547bea998888e6e25c5886a90e762272bc88b5275343dd2c05ded6ca2e360" origin="repo.maven.apache.org/maven2/"/>
+            <artifact name="gson-2.12.0.pom">
+                <sha256 value="ee4cb3d1d489b7ceb8bc73805e024cd36a12d19816585c8b0d46cfd8b604ea46" origin="repo.maven.apache.org/maven2/"/>
             </artifact>
         </component>
 

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -32,20 +32,17 @@
       </trusted-keys>
    </configuration>
     <components>
-        <component group="com.google.code.gson" name="gson-parent" version="2.10.1">
-            <artifact name="gson-parent-2.10.1.pom">
-                <sha256 value="4248e0882426c615182385d6086c3ef3262e769957189e29306280b85482b833" origin="repo.maven.apache.org/maven2/"/>
+        <component group="com.google.code.gson" name="gson-parent" version="2.11.0">
+            <artifact name="gson-parent-2.11.0.pom">
+                <sha256 value="8acb1f3b72a6f026916ac0735bad9aab0293d527edb7b365327def13a9367b7a" origin="repo.maven.apache.org/maven2/"/>
             </artifact>
         </component>
-        <component group="com.google.code.gson" name="gson" version="2.10.1">
-            <artifact name="gson-2.10.1.jar">
-                <sha256 value="4241c14a7727c34feea6507ec801318a3d4a90f070e4525681079fb94ee4c593" origin="repo.maven.apache.org/maven2/"/>
+        <component group="com.google.code.gson" name="gson" version="2.11.0">
+            <artifact name="gson-2.11.0.jar">
+                <sha256 value="57928d6e5a6edeb2abd3770a8f95ba44dce45f3b23b7a9dc2b309c581552a78b" origin="repo.maven.apache.org/maven2/"/>
             </artifact>
-            <artifact name="gson-2.10.1.pom">
-                <sha256 value="d2b115634f5c085db4b9c9ffc2658e89e231fdbfbe2242121a1cd95d4d948dd7" origin="repo.maven.apache.org/maven2/"/>
-            </artifact>
-            <artifact name="gson-2.10.1-sources.jar">
-                <sha256 value="eee1cc5c1f4267ee194cc245777e68084738ef390acd763354ce0ff6bfb7bcc1" origin="repo.maven.apache.org/maven2/"/>
+            <artifact name="gson-2.11.0.pom">
+                <sha256 value="c0e547bea998888e6e25c5886a90e762272bc88b5275343dd2c05ded6ca2e360" origin="repo.maven.apache.org/maven2/"/>
             </artifact>
         </component>
 

--- a/headlong.properties
+++ b/headlong.properties
@@ -1,4 +1,4 @@
 repository=/.m2/repository
-gson_path=/com/google/code/gson/gson/2.10.1
+gson_path=/com/google/code/gson/gson/2.11.0
 project.name=headlong
 project.version=12.3.4-SNAPSHOT

--- a/headlong.properties
+++ b/headlong.properties
@@ -1,4 +1,4 @@
 repository=/.m2/repository
-gson_path=/com/google/code/gson/gson/2.11.0
+gson_path=/com/google/code/gson/gson/2.12.0
 project.name=headlong
 project.version=12.3.4-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,15 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <version>2.11.0</version>
             <scope>provided</scope>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.11.0</version>
+            <version>2.12.0</version>
             <scope>provided</scope>
             <optional>true</optional>
             <exclusions>

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -19,6 +19,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonObject;
+import com.google.gson.Strictness;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
@@ -29,6 +30,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -119,7 +121,7 @@ public final class ABIJSON {
     }
 
     public static <T extends ABIObject> List<T> parseElements(int flags, String arrayJson, Set<TypeEnum> types) {
-        try (final JsonReader reader = read(arrayJson)) {
+        try (final JsonReader reader = reader(arrayJson)) {
             return parseArray(reader, types, flags);
         } catch (IOException io) {
             throw new IllegalStateException(io);
@@ -143,7 +145,7 @@ public final class ABIJSON {
     }
 
     public static <T extends ABIObject> List<T> parseABIField(int flags, String objectJson, Set<TypeEnum> types) {
-        try (final JsonReader reader = read(objectJson)) {
+        try (final JsonReader reader = reader(objectJson)) {
             reader.beginObject();
             while (reader.peek() != JsonToken.END_OBJECT) {
                 if ("abi".equals(reader.nextName())) {
@@ -285,7 +287,7 @@ public final class ABIJSON {
         JsonSpliterator(String arrayJson, Set<TypeEnum> types, int flags) {
             super(Long.SIZE, ORDERED | NONNULL | IMMUTABLE);
             try {
-                JsonReader reader = read(arrayJson);
+                JsonReader reader = reader(arrayJson);
                 reader.beginArray();
                 this.jsonReader = reader;
                 this.types = types;
@@ -341,12 +343,12 @@ public final class ABIJSON {
     }
 
     static <T extends ABIObject> T parseABIObject(String json, Set<TypeEnum> types, MessageDigest digest, int flags) {
-        return parseABIObject(read(json), types, digest, flags);
+        return parseABIObject(reader(json), types, digest, flags);
     }
 
     /** Reads an {@link ABIObject} from JSON and closes the {@link InputStream}. Assumes UTF-8 encoding. */
     static <T extends ABIObject> T parseABIObject(InputStream is, Set<TypeEnum> types, MessageDigest digest, int flags) {
-        return parseABIObject(new JsonReader(new InputStreamReader(is, StandardCharsets.UTF_8)), types, digest, flags);
+        return parseABIObject(reader(is), types, digest, flags);
     }
 
     private static <T extends ABIObject> T parseABIObject(JsonReader reader, Set<TypeEnum> types, MessageDigest digest, int flags) {
@@ -388,7 +390,7 @@ public final class ABIJSON {
             }
         }
         reader.endObject();
-        JsonReader r = read(jsonObject.toString());
+        JsonReader r = reader(jsonObject.toString());
         r.beginObject();
         return finishParse(t, r, digest, flags);
     }
@@ -542,8 +544,18 @@ public final class ABIJSON {
         }
     }
 
-    private static JsonReader read(String json) {
-        return new JsonReader(new StringReader(json));
+    private static JsonReader reader(String json) {
+        return strict(new StringReader(json));
+    }
+
+    private static JsonReader reader(InputStream input) {
+        return strict(new InputStreamReader(input, StandardCharsets.UTF_8));
+    }
+
+    private static JsonReader strict(Reader reader) {
+        JsonReader jsonReader = new JsonReader(reader);
+        jsonReader.setStrictness(Strictness.STRICT);
+        return jsonReader;
     }
 
     private static <T extends ABIObject> List<T> parseArray(final JsonReader reader, Set<TypeEnum> types, int flags) throws IOException {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -564,10 +564,9 @@ public final class ABIJSON {
 
     private static Pair<Enum<?>, Method> reflect() {
         try {
+            final Class<?> c = Class.forName("com.google.gson.Strictness");
             @SuppressWarnings({"unchecked", "rawtypes"})
-            Class<Enum> c = (Class<Enum>) Class.forName("com.google.gson.Strictness");
-            @SuppressWarnings("unchecked")
-            Enum<?> strict = Enum.valueOf(c, "STRICT");
+            final Enum<?> strict = Enum.valueOf((Class<Enum>) c, "STRICT");
             return Tuple.of(strict, JsonReader.class.getMethod("setStrictness", c));
         } catch (Exception ignored) {
             return new Pair<>(new Object[] { null, null });

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -572,7 +572,7 @@ public final class ABIJSON {
         if (STRICTNESS_CLASS != null && !invokeFailed) {
             try {
                 JsonReader.class.getMethod("setStrictness", STRICTNESS_CLASS) // jsonReader.setStrictness(Strictness.STRICT);
-                        .invoke(jsonReader, Enum.valueOf((Class<? extends Enum>) STRICTNESS_CLASS, "STRICT"));
+                                .invoke(jsonReader, Enum.valueOf((Class<Enum>) STRICTNESS_CLASS, "STRICT"));
             } catch (NoSuchMethodException | InvocationTargetException roe) {
                 throw new IllegalStateException(roe);
             } catch (ReflectiveOperationException roe) {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -580,7 +580,7 @@ public final class ABIJSON {
         if (SET_STRICTNESS != null && !invokeFailed) {
             try {
                 SET_STRICTNESS.invoke(jsonReader, STRICT);
-            } catch (ReflectiveOperationException | LinkageError throwable) {
+            } catch (ReflectiveOperationException | IllegalArgumentException | LinkageError throwable) {
                 invokeFailed = true;
                 throwable.printStackTrace();
                 System.err.println("Falling back on legacy strictness");

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -461,7 +461,7 @@ public final class ABIJSON {
         return new ContractError<>(name, tt);
     }
 
-    private static TupleType<?> parseTupleType(JsonReader reader, final boolean eventParams, final int flags) throws IOException {
+    private static TupleType<?> parseTupleType(final JsonReader reader, final boolean eventParams, final int flags) throws IOException {
         if (reader.peek() == JsonToken.NULL) {
             reader.nextNull();
             return TupleType.empty(flags);
@@ -555,7 +555,7 @@ public final class ABIJSON {
     private static volatile boolean fallback = false;
 
     @SuppressWarnings("deprecation")
-    private static JsonReader strict(final Reader reader) {
+    private static JsonReader strict(Reader reader) {
         final JsonReader jsonReader = new JsonReader(reader);
         if (!fallback) {
             try {

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -19,7 +19,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonObject;
-import com.google.gson.Strictness;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
@@ -552,9 +551,10 @@ public final class ABIJSON {
         return strict(new InputStreamReader(input, StandardCharsets.UTF_8));
     }
 
+    @SuppressWarnings("deprecation")
     private static JsonReader strict(Reader reader) {
         JsonReader jsonReader = new JsonReader(reader);
-        jsonReader.setStrictness(Strictness.STRICT);
+        jsonReader.setLenient(false); // jsonReader.setStrictness(Strictness.STRICT);
         return jsonReader;
     }
 

--- a/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
+++ b/src/main/java/com/esaulpaugh/headlong/abi/ABIJSON.java
@@ -561,7 +561,7 @@ public final class ABIJSON {
             try {
                 jsonReader.setStrictness(Strictness.STRICT);
                 return jsonReader;
-            } catch (LinkageError le) {
+            } catch (LinkageError le) { // e.g. at runtime, gson is below 2.11.0
                 fallback = true;
             }
         }


### PR DESCRIPTION
use gson v2.12.0 by default;
parse json more strictly (strictness depends on gson version, v2.11.0+ is more strict);
require gson v2.11.0 or greater to compile;
raise minumum gson version at runtime from 2.0 to 2.1;
improve dependency resolution rules for gson;
raise minumum gradle version to 5.0;
add note to README on how to get best JSON parsing performance;